### PR TITLE
Enforce `MAX_DEGREE` and create efficient `X^n` methods

### DIFF
--- a/.github/workflows/lint-spell.yml
+++ b/.github/workflows/lint-spell.yml
@@ -14,6 +14,10 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# If this workflow keeps failing, edit eyelid/.codespellrc to add more words to ignore,
+# <https://github.com/codespell-project/actions-codespell#usage>
+# or temporarily disable this workflow using the three dots next to "filter workflow runs" in the Actions tab
+# <https://github.com/Inversed-Tech/eyelid/actions/workflows/lint-spell.yml>
 jobs:
   codespell:
     name: Check Spelling
@@ -28,4 +32,5 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          only_warn: true
+          # setting this to any value will disable errors but keep annotations
+          #only_warn: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ark-std = "0.4.0"
 bitvec = "1.0.1"
 # Full list at https://github.com/JelteF/derive_more/blob/v0.99.17/Cargo.toml#L42
 # When we upgrade to 1.0.0, it will be at https://github.com/JelteF/derive_more/blob/master/Cargo.toml#L49
-derive_more = { version = "0.99.17", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "from", "into", "mul", "mul_assign", "not"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "into", "mul", "mul_assign", "not"] }
 
 # Compile-time checks of production code
 static_assertions = "1.1.0"

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -4,7 +4,7 @@
 
 use std::ops::{Add, Sub};
 
-use ark_ff::{One, Zero};
+use ark_ff::Zero;
 use ark_poly::polynomial::Polynomial;
 
 pub use fq::{Coeff, MAX_POLY_DEGREE};
@@ -93,10 +93,8 @@ pub fn karatsuba_mul(a: &Poly, b: &Poly) -> Poly {
         res = res.sub(&arbr);
 
         // If `a` is reduced, then `xnb2` will never need to be reduced.
-        // Setting the leading coefficient to 1 also creates a polynomial in the canonical form.
         let halfn = n / 2;
-        let mut xnb2 = Poly::zero();
-        xnb2[halfn] = Coeff::one();
+        let xnb2 = Poly::xn(halfn);
 
         res = cyclotomic_mul(&res.clone(), &xnb2);
         res = res.add(albl);
@@ -107,11 +105,9 @@ pub fn karatsuba_mul(a: &Poly, b: &Poly) -> Poly {
             // Otherwise proceed as usual
             //
             // Even if `a` is reduced, `n` can still be over the maximum degree.
-            // But setting the leading coefficient to 1 does create a polynomial in the canonical form.
-            let mut xn = Poly::zero();
-            xn[n] = Coeff::one();
-            // This will only reduce in the initial case, when `a` is the maximum reduced degree.
+            // But it will only reduce in the initial case, when `a` is the maximum reduced degree.
             // And the reduction is quick, because it is only a single index.
+            let mut xn = Poly::xn(n);
             xn.reduce_mod_poly();
 
             let aux = cyclotomic_mul(&arbr, &xn);

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -8,19 +8,27 @@ use ark_ff::{One, Zero};
 use ark_poly::polynomial::Polynomial;
 
 pub use fq::{Coeff, MAX_POLY_DEGREE};
-pub use modular_poly::{mod_poly, Poly, POLY_MODULUS};
+pub use modular_poly::{
+    modulus::{mod_poly, POLY_MODULUS},
+    Poly,
+};
 
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(not(any(test, feature = "benchmark")))]
-use modular_poly::{mod_poly_ark_ref, mod_poly_manual_mut};
+use modular_poly::modulus::{mod_poly_ark_ref, mod_poly_manual_mut};
 #[cfg(any(test, feature = "benchmark"))]
-pub use modular_poly::{mod_poly_ark_ref, mod_poly_manual_mut};
+pub use modular_poly::modulus::{mod_poly_ark_ref, mod_poly_manual_mut};
 
 pub mod fq;
 pub mod modular_poly;
 
 #[cfg(any(test, feature = "benchmark"))]
 pub mod test;
+
+// TODO: move low-level multiplication code to `modular_poly::mul`
+
+/// The fastest available cyclotomic polynomial multiplication operation (multiply then reduce).
+pub use cyclotomic_mul as mul_poly;
 
 /// Minimum degree for recursive Karatsuba calls
 pub const MIN_KARATSUBA_REC_DEGREE: usize = 32; // TODO: fine tune

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -3,6 +3,9 @@
 //! Outside this module, use [`fq::Coeff`](Coeff) and [`fq::MAX_POLY_DEGREE`](MAX_POLY_DEGREE) instead of `fq79` or `fq_tiny`.
 //! This automatically enables CI tests on both fields.
 
+use ark_ff::Zero;
+use lazy_static::lazy_static;
+
 mod fq79;
 mod fq_tiny;
 
@@ -16,3 +19,21 @@ pub use fq79::{Coeff, MAX_POLY_DEGREE};
 // ```
 #[cfg(tiny_poly)]
 pub use fq_tiny::{Coeff, MAX_POLY_DEGREE};
+
+lazy_static! {
+    /// The zero coefficient as a static constant value.
+    ///
+    /// # Usage
+    ///
+    /// Return `&super::fq::COEFF_ZERO` from a function that returns a reference to `Coeff::zero()`.
+    ///
+    /// Only use this constant when you need a long-lived reference to a zero coefficient value.
+    /// The compiler will tell you, with errors like:
+    /// > cannot return reference to a temporary value
+    /// > returns a reference to data owned by the current function
+    ///
+    /// Typically, `Coeff::zero()` is more readable and efficient.
+    pub static ref COEFF_ZERO: Coeff = {
+        Coeff::zero()
+    };
+}

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -5,6 +5,12 @@
 //! - the leading coefficient is set to zero, including when the polynomial is split or truncated, or
 //! - the degree of the polynomial is increased, for example, during multiplication.
 
+// Optional TODOs:
+// - re-implement IndexMut manually, to enforce the canonical form (highest coefficient is non-zero) and modular arithmetic
+//   (this can be done by returning a new type with `DerefMut<Target = Coeff>``, but it could have performance impacts)
+// Trivial:
+// - implement Sum manually
+
 use std::ops::{Index, IndexMut, Mul};
 
 use ark_ff::{One, Zero};
@@ -51,7 +57,6 @@ lazy_static! {
     Hash,
     AsRef,
     Deref,
-    // TODO: manually implement a final reduce step
     DerefMut,
     // TODO: manually implement a final reduce step
     From,
@@ -69,10 +74,6 @@ lazy_static! {
 )]
 pub struct Poly(DensePolynomial<Coeff>);
 
-// TODO:
-// - enforce the constant degree MAX_POLY_DEGREE
-// - re-implement Index and IndexMut manually, to enforce the canonical form (highest coefficient is non-zero) and modular arithmetic
-// - re-implement Mul and MulAssign manually, to enforce modular arithmetic by POLY_MODULUS (Add, Sub, Div, Rem, and Neg can't increase the degree)
 impl Poly {
     // Shadow DenseUVPolynomial methods, so we don't have to implement Polynomial and all its supertraits.
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -13,7 +13,7 @@
 
 use std::ops::{Index, IndexMut, Mul};
 
-use ark_ff::Zero;
+use ark_ff::{One, Zero};
 use ark_poly::polynomial::univariate::{
     DenseOrSparsePolynomial, DensePolynomial, SparsePolynomial,
 };
@@ -50,14 +50,26 @@ impl Poly {
 
     /// Converts the `coeffs` vector into a dense polynomial.
     pub fn from_coefficients_vec(coeffs: Vec<Coeff>) -> Self {
-        let mut new = Self(DensePolynomial { coeffs });
-        new.truncate_to_canonical_form();
-        new
+        let mut poly = Self(DensePolynomial { coeffs });
+        poly.truncate_to_canonical_form();
+        poly
     }
 
     /// Converts the `coeffs` slice into a dense polynomial.
     pub fn from_coefficients_slice(coeffs: &[Coeff]) -> Self {
         Self::from_coefficients_vec(coeffs.to_vec())
+    }
+
+    // Efficient Re-Implementations
+
+    /// Returns `X^n` as a polynomial in reduced form.
+    pub fn xn(n: usize) -> Self {
+        let mut poly = Self::zero();
+        poly[n] = Coeff::one();
+
+        poly.reduce_mod_poly();
+
+        poly
     }
 
     // Basic Internal Operations

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -21,11 +21,16 @@ use derive_more::{Add, AsRef, Deref, DerefMut, Div, Into, Neg, Rem};
 
 use crate::primitives::poly::{mod_poly, mul_poly, Coeff};
 
+// Doc links
+#[allow(unused_imports)]
+use crate::primitives::poly::{modular_poly::modulus::POLY_MODULUS, MAX_POLY_DEGREE};
+
 pub(super) mod modulus;
 
 mod trivial;
 
 /// A modular polynomial with coefficients in [`Coeff`], and maximum degree [`MAX_POLY_DEGREE`].
+/// The un-reduced polynomial modulus is [`POLY_MODULUS`](static@POLY_MODULUS).
 #[derive(
     Clone,
     Debug,

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -72,7 +72,34 @@ impl Poly {
         poly
     }
 
+    /// Multiplies `self` by `X^n`, then reduces if needed.
+    pub fn mul_xn(&mut self, n: usize) {
+        // Puts `n` zeroes as the highest coefficients of the polynomial.
+        let new_len = self.coeffs.len() + n;
+        self.coeffs.resize(new_len, Coeff::zero());
+
+        // Moves those `n` zeroes to the lowest coefficients of the polynomial, and shifts the rest up.
+        self.coeffs.rotate_right(n);
+
+        self.reduce_mod_poly();
+    }
+
+    /// Divides `self` by `X^n`, and returns `(quotient, remainder)`.
+    pub fn div_xn(mut self, n: usize) -> (Self, Self) {
+        // Make `self` the remainder by splitting off the quotient.
+        let quotient = self.coeffs.split_off(n);
+
+        (Self::from_coefficients_vec(quotient), self)
+    }
+
     // Basic Internal Operations
+
+    /// Multiplies two polynomials, and returns the result in reduced form.
+    ///
+    /// This operation can be called using the `*` operator, this method is only needed to disambiguate.
+    pub fn mul_reduce(&self, rhs: &Self) -> Poly {
+        mul_poly(self, rhs)
+    }
 
     /// Reduce this polynomial so it is less than [`POLY_MODULUS`](static@POLY_MODULUS).
     /// This also ensures its degree is less than [`MAX_POLY_DEGREE`].

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -1,0 +1,92 @@
+//! Reduction by the polynomial modulus.
+
+use ark_ff::{One, Zero};
+use ark_poly::polynomial::{univariate::DenseOrSparsePolynomial, Polynomial};
+use lazy_static::lazy_static;
+
+use crate::primitives::poly::{Coeff, Poly, MAX_POLY_DEGREE};
+
+lazy_static! {
+    /// The polynomial modulus used for the polynomial field, `X^[MAX_POLY_DEGREE] + 1`.
+    /// This means that `X^[MAX_POLY_DEGREE] = -1`.
+    ///
+    /// This is the canonical but un-reduced form of the modulus, because the reduced form is the zero polynomial.
+    pub static ref POLY_MODULUS: DenseOrSparsePolynomial<'static, Coeff> = {
+        let mut poly = Poly::zero();
+
+        // Since the leading coefficient is non-zero, this is in canonical form.
+        // Resize to the maximum size first, to avoid repeated reallocations.
+        poly[MAX_POLY_DEGREE] = Coeff::one();
+        poly[0] = Coeff::one();
+
+        // Check canonicity and degree.
+        assert_eq!(poly.degree(), MAX_POLY_DEGREE);
+
+        poly.into()
+    };
+}
+
+/// The fastest available modular polynomial operation.
+pub use mod_poly_manual_mut as mod_poly;
+
+/// Reduces `dividend` to `dividend % [POLY_MODULUS]`.
+///
+/// This is the most efficient manual implementation.
+pub fn mod_poly_manual_mut(dividend: &mut Poly) {
+    let mut i = MAX_POLY_DEGREE;
+    while i < dividend.coeffs.len() {
+        let q = i / MAX_POLY_DEGREE;
+        let r = i % MAX_POLY_DEGREE;
+
+        // In the cyclotomic ring we have that XˆN = -1,
+        // therefore all elements from N to 2N-1 are negated.
+        //
+        // For performance reasons, we use <Vec as IndexMut>,
+        // because the loop condition limits `i` to valid indexes.
+        if q % 2 == 1 {
+            dividend.coeffs[r] = dividend.coeffs[r] - dividend.coeffs[i];
+        } else {
+            dividend.coeffs[r] = dividend.coeffs[r] + dividend.coeffs[i];
+        }
+        i += 1;
+    }
+
+    // The coefficients of MAX_POLY_DEGREE and higher have already been summed above.
+    dividend.coeffs.truncate(MAX_POLY_DEGREE);
+
+    // The coefficients could sum to zero, so make sure the polynomial is in the canonical form.
+    dividend.truncate_to_canonical_form();
+}
+
+/// Returns the remainder of `dividend % [POLY_MODULUS]`, as a polynomial.
+///
+/// This clones then uses the manual implementation.
+#[cfg(inefficient)]
+pub fn mod_poly_manual_ref(dividend: &Poly) -> Poly {
+    let mut dividend = dividend.clone();
+    mod_poly_manual_mut(&mut dividend);
+    dividend
+}
+
+/// Returns the remainder of `dividend % [POLY_MODULUS]`, as a polynomial.
+///
+/// This uses an [`ark-poly`] library implementation, which always creates a new polynomial.
+pub fn mod_poly_ark_ref(dividend: &Poly) -> Poly {
+    let dividend: DenseOrSparsePolynomial<'_, _> = dividend.into();
+
+    // The DenseOrSparsePolynomial implementation ensures canonical form.
+    let (_quotient, remainder) = dividend
+        .divide_with_q_and_r(&*POLY_MODULUS)
+        .expect("POLY_MODULUS is not zero");
+
+    remainder.into()
+}
+
+/// Reduces `dividend` to `dividend % [POLY_MODULUS]`.
+///
+/// This uses an [`ark-poly`] library implementation, and entirely replaces the inner polynomial representation.
+#[cfg(inefficient)]
+pub fn mod_poly_ark_mut(dividend: &mut Poly) {
+    let remainder = mod_poly_ark_ref(dividend);
+    *dividend = remainder;
+}

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -5,7 +5,7 @@
 
 use std::{
     borrow::Borrow,
-    ops::{Add, AddAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Sub, SubAssign, Mul},
 };
 
 use ark_ff::{One, Zero};
@@ -104,5 +104,14 @@ impl SubAssign<Poly> for Poly {
 impl SubAssign<&Poly> for Poly {
     fn sub_assign(&mut self, rhs: &Self) {
         self.0 -= &rhs.0;
+    }
+}
+
+// Multiplying by a scalar can't increase the degree, so it is trivial.
+impl Mul<Coeff> for Poly {
+    type Output = Self;
+
+    fn mul(self, rhs: Coeff) -> Self {
+        Poly(&self.0 * rhs)
     }
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -13,10 +13,6 @@ use ark_poly::polynomial::univariate::{DenseOrSparsePolynomial, DensePolynomial}
 
 use crate::primitives::poly::modular_poly::{Coeff, Poly};
 
-// TODO:
-// Optional:
-// - implement Sum manually
-
 impl Borrow<DensePolynomial<Coeff>> for Poly {
     fn borrow(&self) -> &DensePolynomial<Coeff> {
         &self.0

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -5,7 +5,7 @@
 
 use std::{
     borrow::Borrow,
-    ops::{Add, AddAssign, Sub, SubAssign, Mul},
+    ops::{Add, AddAssign, Mul, Sub, SubAssign},
 };
 
 use ark_ff::{One, Zero};

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -18,11 +18,7 @@ fn test_cyclotomic_mul_rand() {
     }
 
     // Xˆ{N-1}, multiplying by it will rotate by N-1 and negate (except the first).
-    //
-    // Since the degree is less than MAX_POLY_DEGREE, this is already reduced.
-    // It is also in canonical form, because the leading coefficient is non-zero.
-    let mut xnm1 = Poly::zero();
-    xnm1[MAX_POLY_DEGREE - 1] = Coeff::one();
+    let xnm1 = Poly::xn(MAX_POLY_DEGREE - 1);
 
     assert_eq!(xnm1.degree(), MAX_POLY_DEGREE - 1);
 
@@ -85,15 +81,16 @@ fn test_cyclotomic_mul_max_degree() {
 
         // X^i * X^{MAX_POLY_DEGREE - i} = X^MAX_POLY_DEGREE
 
-        // `p1` and `p2` are only reduced when i is `1..=(MAX_POLY_DEGREE-1)`.`
-        // But they are always in canonical form, because the leading coefficient is non-zero.
-        let mut p1 = Poly::zero();
-        p1[i] = Coeff::one();
+        // `p1` and `p2` are automatically reduced if needed.
+        let p1 = Poly::xn(i);
+        let p2 = Poly::xn(MAX_POLY_DEGREE - i);
 
-        let mut p2 = Poly::zero();
-        p2[MAX_POLY_DEGREE - i] = Coeff::one();
-
-        assert_eq!(p1.degree() + p2.degree(), MAX_POLY_DEGREE);
+        if i == 0 || i == MAX_POLY_DEGREE {
+            assert_eq!(p1.degree(), 0);
+            assert_eq!(p2.degree(), 0);
+        } else {
+            assert_eq!(p1.degree() + p2.degree(), MAX_POLY_DEGREE);
+        }
 
         let res = cyclotomic_mul(&p1, &p2);
 


### PR DESCRIPTION
This PR:
- ensures `MAX_DEGREE` is enforced by:
  - reducing after all the possible conversions
  - using cyclotomic multiplication for `Mul` implementations
- adds efficient implementations for:
  - new `X^n`
  - mul `X^n`
  - div `X^n`
- moves modular reduction to its own module file, so private methods can't accidentally be called

Also:
- fixes CI spell check behaviour

Close #13.