### PR TITLE
Enable compiler optimization settings that reliably increase performance in the Rust configs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,14 @@
-# This file enabled clippy lints
+[build]
+# Low-level performance settings
+rustflags = ["-C", "target-cpu=native"]
+
+# Enable rustdoc lints
+rustdocflags = [
+    # Links in public docs can point to private items.
+    "-Arustdoc::private_intra_doc_links",
+]
+
+# Enable rustc and clippy lints.
 # Lint settings are configured in clippy.toml
 
 # Based on:
@@ -75,8 +85,3 @@ rustflags = [
     "-Wclippy::cast_sign_loss",
 ]
 
-[build]
-rustdocflags = [
-    # Links in public docs can point to private items.
-    "-Arustdoc::private_intra_doc_links",
-]

--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -14,6 +14,18 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# The actions variables and shell env namespaces are different, so we need to import every relevant variable here:
+# <https://github.com/Inversed-Tech/eyelid/settings/variables/actions>
+env:
+  # Logging
+  CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
+  # For performance reasons, benchmarks have their own log level, which should typically be `off` or `0`.
+  RUST_LOG: ${{ vars.RUST_LOG_BENCHMARKS }}
+  # These backtrace variables are used by the `backtrace` crate to control the backtrace verbosity in binaries and libraries.
+  # We always want them set to the same value in CI. 
+  RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE_BENCHMARKS }}
+  RUST_LIB_BACKTRACE: ${{ vars.RUST_BACKTRACE_BENCHMARKS }}
+
 jobs:
   bench:
     name: Rust Benchmarks

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,10 +33,13 @@ jobs:
       # We want to run tiny_poly to completion, so bugs are easier to diagnose
       fail-fast: false      
       matrix:
-        # rustc config options
-        cfg: ["", "--cfg tiny_poly"]
-        # cargo feature options, "--no-default-features" is the same as "" for now
-        features: ["", "--all-features"]
+        # rustc config options:
+        # * "--cfg tiny_poly" is covered by ci-test.yml
+        cfg: [""]
+        # cargo feature options:
+        # * "--no-default-features" is the same as "" for now
+        # * "--all-features" is the same as "--features benchmark" for now, which is covered by ci-bench.yml
+        features: [""]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,17 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# The actions variables and shell env namespaces are different, so we need to import every relevant variable here:
+# <https://github.com/Inversed-Tech/eyelid/settings/variables/actions>
+env:
+  # Logging
+  CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
+  RUST_LOG: ${{ vars.RUST_LOG }}
+  # These backtrace variables are used by the `backtrace` crate to control the backtrace verbosity in binaries and libraries.
+  # We always want them set to the same value in CI. 
+  RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
+  RUST_LIB_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
+
 jobs:
   build:
     name: Rust Build and Run

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,6 +14,17 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# The actions variables and shell env namespaces are different, so we need to import every relevant variable here:
+# <https://github.com/Inversed-Tech/eyelid/settings/variables/actions>
+env:
+  # Logging
+  CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
+  RUST_LOG: ${{ vars.RUST_LOG }}
+  # These backtrace variables are used by the `backtrace` crate to control the backtrace verbosity in binaries and libraries.
+  # We always want them set to the same value in CI. 
+  RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
+  RUST_LIB_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
+
 jobs:
   test:
     name: Rust Tests

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,8 +35,10 @@ jobs:
       matrix:
         # rustc config options
         cfg: ["", "--cfg tiny_poly"]
-        # cargo feature options, "--no-default-features" is the same as "" for now
-        features: ["", "--all-features"]
+        # cargo feature options:
+        # * "--no-default-features" is the same as "" for now
+        # * "--all-features" is the same as "--features benchmark" for now, which is covered by ci-bench.yml
+        features: [""]
     
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint-clippy.yml
+++ b/.github/workflows/lint-clippy.yml
@@ -14,6 +14,12 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# The actions variables and shell env namespaces are different, so we need to import every relevant variable here:
+# <https://github.com/Inversed-Tech/eyelid/settings/variables/actions>
+env:
+  # Logging
+  CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
+
 jobs:
   clippy:
     name: Check Rust Lints

--- a/.github/workflows/lint-clippy.yml
+++ b/.github/workflows/lint-clippy.yml
@@ -29,7 +29,8 @@ jobs:
       matrix:
         # rustc config options
         cfg: ["", "--cfg tiny_poly"]
-        # cargo feature options: "--all-features" covers "" and "--no-default-features" for now
+        # cargo feature options
+        # * "--all-features" covers "" and "--no-default-features" for now, because our features only add code
         features: ["--all-features"]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -14,6 +14,12 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# The actions variables and shell env namespaces are different, so we need to import every relevant variable here:
+# <https://github.com/Inversed-Tech/eyelid/settings/variables/actions>
+env:
+  # Logging
+  CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
+
 jobs:
   docs:
     name: Check Docs

--- a/.github/workflows/lint-rustfmt.yml
+++ b/.github/workflows/lint-rustfmt.yml
@@ -14,6 +14,12 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+# The actions variables and shell env namespaces are different, so we need to import every relevant variable here:
+# <https://github.com/Inversed-Tech/eyelid/settings/variables/actions>
+env:
+  # Logging
+  CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
+
 jobs:
   bench:
     name: Check Rust Formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,18 @@ criterion = { version = "0.5.1", default-features = false, features = ["cargo_be
 lazy_static = "1.4.0"
 rand = "0.8.5"
 
+# Compilation settings for performance
+[profile.release]
+panic = "abort"
+lto = true
+strip = "debuginfo"
+codegen-units = 1
+
+[profile.bench]
+panic = "abort"
+lto = true
+strip = "debuginfo"
+codegen-units = 1
+
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
This makes our benchmarks more accurate.

This PR also reduces the number of duplicate checks, and duplicate annotations in PRs.

Close #22
Close #34 