### PR TITLE
Extended GCD and Inverses

### DIFF
--- a/eyelid-match-ops/Cargo.toml
+++ b/eyelid-match-ops/Cargo.toml
@@ -17,7 +17,6 @@ version.workspace = true
 # Benchmark-only dependencies
 benchmark = [
     "criterion",
-    "rand",
 ]
 
 # Temporarily switch to a tiny field to make test errors easier to debug:
@@ -33,11 +32,13 @@ bitvec.workspace = true
 derive_more.workspace = true
 
 lazy_static.workspace = true
+
+rand.workspace = true
+
 static_assertions.workspace = true
 
 # Benchmark-only dependencies
 criterion = {workspace = true, optional = true}
-rand = {workspace = true, optional = true}
 
 [dev-dependencies]
 eyelid-test.workspace = true

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -226,7 +226,10 @@ pub fn bench_mod_poly_ark(settings: &mut Criterion) {
 /// Run [`poly::inverse()`] as a Criterion benchmark with random data.
 pub fn bench_inv(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p = sample::<FULL_RES_POLY_DEGREE>();
+
+    let rng = rand::thread_rng();
+
+    let p = sample::<FULL_RES_POLY_DEGREE>(rng);
 
     settings.bench_with_input(
         BenchmarkId::new(

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -12,9 +12,8 @@ use eyelid_match_ops::{
         self,
         test::gen::{random_iris_code, random_iris_mask},
     },
-    primitives::poly::{self, test::gen::rand_poly, MAX_POLY_DEGREE},
+    primitives::poly::{self, test::gen::rand_poly, test::inv::sample, MAX_POLY_DEGREE},
 };
-use eyelid_match_ops::primitives::poly::sample;
 
 // Configure Criterion:
 // Define one group for each equivalent operation, so we can compare their times.

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -223,7 +223,7 @@ pub fn bench_mod_poly_ark(settings: &mut Criterion) {
     );
 }
 
-/// Run [`poly::karatsuba_mul()`] as a Criterion benchmark with random data.
+/// Run [`poly::inverse()`] as a Criterion benchmark with random data.
 pub fn bench_inv(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
     let p = sample::<FULL_RES_POLY_DEGREE>();

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -12,7 +12,7 @@ use eyelid_match_ops::{
         self,
         test::gen::{random_iris_code, random_iris_mask},
     },
-    primitives::poly::{self, test::gen::rand_poly, test::inv::sample, Poly, FULL_RES_POLY_DEGREE},
+    primitives::poly::{self, sample, test::gen::rand_poly, Poly, FULL_RES_POLY_DEGREE},
 };
 
 // Configure Criterion:

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -5,7 +5,7 @@
 
 use ark_ff::{Field, One, Zero};
 use ark_poly::polynomial::Polynomial;
-use rand::Rng;
+use rand::{rngs::ThreadRng, Rng};
 
 pub use fq::Coeff;
 pub use modular_poly::{
@@ -123,10 +123,9 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
     (x_prev, y_prev, ri_prev)
 }
 
-/// This sampling is similar to what will be necessary for YASHE KeyGen
-/// TODO: generate Gaussian distribution instead of "uniform"
-pub fn sample<const MAX_POLY_DEGREE: usize>() -> Poly<MAX_POLY_DEGREE> {
-    let mut rng = rand::thread_rng();
+/// This sampling is similar to what will be necessary for YASHE KeyGen.
+/// The purpose is to obtain a polynomial with small random coefficients.
+pub fn sample<const MAX_POLY_DEGREE: usize>(mut rng: ThreadRng) -> Poly<MAX_POLY_DEGREE> {
     let mut res = Poly::zero();
     let max_coeff = 8;
     let t = 2;

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -29,7 +29,7 @@ pub mod modular_poly;
 #[cfg(any(test, feature = "benchmark"))]
 pub mod test;
 
-/// Returns the inverse in the cyclotomic ring, if it exists.
+/// Returns the monic inverse of `a` in the cyclotomic ring, if it exists.
 /// Otherwise, returns an error.
 pub fn inverse<const MAX_POLY_DEGREE: usize>(
     a: &Poly<MAX_POLY_DEGREE>,
@@ -38,16 +38,20 @@ pub fn inverse<const MAX_POLY_DEGREE: usize>(
 
     let (_x, y, d) = extended_gcd(&unreduced_mod_pol, a);
 
-    // compute the inverse of `d` to calculate the final result
-    if d.degree() == 0 {
+    // If `d` is a non-zero constant, we can compute the inverse of `d`,
+    // and calculate the final inverse.
+    if d.is_zero() {
+        Err("Can't invert the zero polynomial".to_string())
+    } else if d.degree() > 0 {
+        Err("Non-invertible polynomial".to_string())
+    } else {
+        // Reduce to a monic polynomial.
         let mut inv: Poly<MAX_POLY_DEGREE> = y;
-        let divisor_inv: Coeff = d[0].inverse().unwrap();
+        let divisor_inv: Coeff = d[0].inverse().expect("just checked for zero");
 
         inv *= divisor_inv;
 
         Ok(inv)
-    } else {
-        Err("Can't invert polynomial, invalid divisor".to_string())
     }
 }
 

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -74,7 +74,9 @@ pub fn one_poly(degree: usize) -> Poly {
 /// The returned polynomial has maximum degree [`MAX_POLY_DEGREE`].
 pub fn cyclotomic_mul(a: &Poly, b: &Poly) -> Poly {
     // TODO: change these assertions to debug_assert!() to avoid panics in production code.
+    dbg!("bug after");
     assert!(a.degree() <= MAX_POLY_DEGREE);
+    dbg!("bug before");
     assert!(b.degree() <= MAX_POLY_DEGREE);
 
     let dividend = a.naive_mul(b);
@@ -144,8 +146,11 @@ pub fn extended_gcd(a: &Poly, b: Poly) -> (Poly, Poly, Poly) {
     let mut y_prev = zero_poly(MAX_POLY_DEGREE);
     let ri_prev = a.clone();
     // next:     x1=0, y1=1, r1=b
-    let mut x_cur = zero_poly(MAX_POLY_DEGREE);
-    let mut y_cur = one_poly(MAX_POLY_DEGREE);
+    // FIXME: we need a way to create the zero polynomial, whose degree is zero
+    // But right now if we use the zero_poly function, the program will panic when
+    // degree() is called inside cyclotomic_mul
+    let mut x_cur = zero_poly(0);
+    let mut y_cur = one_poly(0);
     let ri_cur = b.clone();
 
     let mut dividend: DenseOrSparsePolynomial<'_, _> = ri_prev.clone().into();

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -105,6 +105,10 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
 
     let mut q: Poly<MAX_POLY_DEGREE>;
 
+    // Sometimes the inputs can be non-canonical.
+    ri_cur.truncate_to_canonical_form();
+
+
     // loop until ri_cur = 0
     while !(ri_cur.is_zero()) {
         let ri_aux = ri_cur.clone();
@@ -112,6 +116,8 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
         (q, ri_cur) = ri_prev
             .divide_with_q_and_r(&ri_cur)
             .expect("just checked that the loop divisor is not zero");
+        // Sometimes divide_with_q_and_r() might be returning a non-canonical polynomial
+        ri_cur.truncate_to_canonical_form();
         ri_prev = ri_aux;
 
         // x_cur = x_prev - q.x_cur

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -15,6 +15,7 @@ pub use modular_poly::{
     Poly,
 };
 use std::ops::Mul;
+use rand::Rng;
 
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(not(any(test, feature = "benchmark")))]
@@ -232,4 +233,19 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
         final_result[i] = final_result[i].mul(divisor_inv);
     }
     final_result
+}
+
+/// This sampling is similar to what will be necessary for YASHE KeyGen
+/// TODO: generate Gaussian distribution instead of "uniform"
+pub fn sample() -> Poly {
+    let mut rng = rand::thread_rng();
+    let mut res = Poly::zero();
+    let max_coeff = 8;
+    let t = 2;
+    for i in 0..MAX_POLY_DEGREE {
+        let coeff_rand = rng.gen_range(1..max_coeff);
+        res[i] = Coeff::from(t * coeff_rand);
+    }
+    res[0] += Coeff::one();
+    res
 }

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -36,24 +36,6 @@ pub use cyclotomic_mul as mul_poly;
 /// Minimum degree for recursive Karatsuba calls
 pub const MIN_KARATSUBA_REC_DEGREE: usize = 32; // TODO: fine tune
 
-/// Returns a Boolean indicating if the input is equal or not to the additive
-/// identity in the polynomial ring
-pub fn is_zero_poly(a: Poly) -> bool {
-    let mut poly = Poly::zero();
-    poly.coeffs = vec![Coeff::zero(); MAX_POLY_DEGREE + 1];
-    poly == a
-}
-
-/// Returns the multiplicative element of the polynomial ring.
-pub fn one_poly(degree: usize) -> Poly {
-    assert!(degree <= MAX_POLY_DEGREE);
-
-    let mut poly = Poly::zero();
-    poly.coeffs = vec![Coeff::zero(); degree + 1];
-    poly.coeffs[0] = Coeff::one();
-    poly
-}
-
 /// Returns `a * b` followed by reduction mod `XˆN + 1`.
 /// The returned polynomial has maximum degree [`MAX_POLY_DEGREE`].
 pub fn cyclotomic_mul(a: &Poly, b: &Poly) -> Poly {

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -61,7 +61,7 @@ pub fn inverse<const MAX_POLY_DEGREE: usize>(
         let mut inv: Poly<MAX_POLY_DEGREE> = y;
         // Compute the inverse of the content
         let content_inv: Coeff = d[0].inverse().expect("just checked for zero");
-
+        // Divide by `content_inv`
         inv *= content_inv;
 
         Ok(inv)

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -149,6 +149,7 @@ pub fn extended_gcd(a: &Poly, b: Poly) -> (Poly, Poly, Poly) {
     // FIXME: we need a way to create the zero polynomial, whose degree is zero
     // But right now if we use the zero_poly function, the program will panic when
     // degree() is called inside cyclotomic_mul
+    // See Issue #13
     let mut x_cur = zero_poly(0);
     let mut y_cur = one_poly(0);
     let ri_cur = b.clone();

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -35,14 +35,14 @@ pub mod test;
 
 /// Implementation based on Algorithm 3.3.1 (Page 118) from
 /// "A Course in Computational Algebraic Number Theory", Henri Cohen.
-/// We don't divide by content of a and b every time,
+/// We don't divide by content of `a` and `b` every time,
 /// just in the end of the algorithm.
 /// Returns the primitive polynomial which is the inverse of `a` in the
 /// cyclotomic ring, if it exists. Otherwise, returns an error.
 ///
 /// When `d` is a constant polynomial and `a` is the polynomial modulus
 /// (which reduces to `0`), we have that `b/cont(d)` is the primitive
-/// multiplicative inverse of `y`. Otherwise, returns an error.
+/// multiplicative inverse of `y`.
 pub fn inverse<const MAX_POLY_DEGREE: usize>(
     a: &Poly<MAX_POLY_DEGREE>,
 ) -> Result<Poly<MAX_POLY_DEGREE>, String> {

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -108,7 +108,6 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
     // Sometimes the inputs can be non-canonical.
     ri_cur.truncate_to_canonical_form();
 
-
     // loop until ri_cur = 0
     while !(ri_cur.is_zero()) {
         let ri_aux = ri_cur.clone();

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -219,11 +219,19 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
         ri_prev = ri_aux.into();
         // x_cur = x_prev - q.x_cur
         (x_cur, x_prev) = update_diophantine(x_prev, x_cur, q.clone().into());
-        // y_cur = y_)prev - q.y_cur
+        // y_cur = y_prev - q.y_cur
         (y_cur, y_prev) = update_diophantine(y_prev, y_cur, q.clone().into());
     }
     // compute ri_prev inverse to calculate the final result
-    let divisor = ri_prev.clone();
+    let mut divisor = ri_prev.clone();
+    // FIXME: if b is not invertible mod a the assert is not going to pass.
+    // Since the test is probabilistic, we have a small chance of failure.
+    // It fails after a small number of executions.
+    // Sometimes it fails with a different error, meaning there is another
+    // problem happening.
+    // It occasionally fails when we do the following:
+    // export RUSTFLAGS="-D warnings --cfg tiny_poly"
+    // cargo test --all-targets -- --nocapture inv
     debug_assert!(divisor.degree() == 0);
     let divisor_inv = divisor[0].inverse().unwrap();
     // y_cur / ri_prev

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -29,6 +29,9 @@ pub mod modular_poly;
 #[cfg(any(test, feature = "benchmark"))]
 pub mod test;
 
+// Do not add code here.
+// Add functions or trait impls to modular_poly/*.rs and inherent method impls to modular_poly.rs.
+
 /// Returns the monic inverse of `a` in the cyclotomic ring, if it exists.
 /// Otherwise, returns an error.
 pub fn inverse<const MAX_POLY_DEGREE: usize>(

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -36,13 +36,9 @@ pub mod test;
 pub fn inverse<const MAX_POLY_DEGREE: usize>(
     a: &Poly<MAX_POLY_DEGREE>,
 ) -> Result<Poly<MAX_POLY_DEGREE>, String> {
-    let mut mod_pol = Poly::zero();
+    let unreduced_mod_pol = Poly::new_unreduced_poly_modulus_slow();
 
-    // TODO: don't recompute the modulus here
-    mod_pol[MAX_POLY_DEGREE] = Coeff::one();
-    mod_pol[0] = Coeff::one();
-
-    extended_gcd(&mod_pol, a)
+    extended_gcd(&unreduced_mod_pol, a)
 }
 
 /// Helps to calculate the equation `cur = prev - q.cur`.

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -2,21 +2,19 @@
 //!
 //! This module contains the base implementations of complex polynomial operations, such as multiplication and reduction.
 
+use ark_ff::Field;
 use std::ops::{Add, Sub};
- use ark_ff::Field;
 
-use std::ops::Mul;
 use ark_ff::One;
 use ark_ff::Zero;
 use ark_poly::polynomial::Polynomial;
 use ark_poly::univariate::DenseOrSparsePolynomial;
-use ark_poly::univariate::DensePolynomial;
-
 pub use fq::{Coeff, MAX_POLY_DEGREE};
 pub use modular_poly::{
     modulus::{mod_poly, POLY_MODULUS},
     Poly,
 };
+use std::ops::Mul;
 
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(not(any(test, feature = "benchmark")))]
@@ -55,7 +53,6 @@ pub fn one_poly(degree: usize) -> Poly {
     poly.coeffs[0] = Coeff::one();
     poly
 }
-
 
 /// Returns `a * b` followed by reduction mod `XˆN + 1`.
 /// The returned polynomial has maximum degree [`MAX_POLY_DEGREE`].
@@ -161,6 +158,7 @@ pub fn poly_split(a: &Poly) -> (Poly, Poly) {
     (al, ar)
 }
 
+/// Returns the inverse in the cyclotomic ring, if it exists.
 pub fn inverse(a: &Poly) -> Result<Poly, String> {
     let mut mod_pol = Poly::zero();
 
@@ -182,7 +180,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
     // Invariant a.xi + b.yi = ri
 
     // init with x0=1, y0=0, r0=a
-    let mut x_prev =  Poly::zero();
+    let mut x_prev = Poly::zero();
     x_prev[0] = Coeff::one();
     let mut y_prev = Poly::zero();
     let mut ri_prev = a.clone();
@@ -196,7 +194,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
     let (mut q, mut ri_cur) = DenseOrSparsePolynomial::from(ri_prev.clone())
         .divide_with_q_and_r(&ri_cur.into())
         .expect("divisor is not zero");
-    ri_prev  = ri_aux;
+    ri_prev = ri_aux;
     // xi+1 = xi-1 - q.xi
     let mut x_aux = x_cur.clone();
     let mul_res_x = x_cur.mul(&q.clone().into());
@@ -213,7 +211,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
         (q, ri_cur) = DenseOrSparsePolynomial::from(ri_prev.clone())
             .divide_with_q_and_r(&ri_cur.into())
             .expect("divisor is not zero");
-        ri_prev  = ri_aux.into();
+        ri_prev = ri_aux.into();
         // xi+1 = xi-1 - q.xi
         x_aux = x_cur.clone();
         let mul_res_x = q.naive_mul(&x_cur);
@@ -230,7 +228,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
     let divisor_inv = divisor[0].inverse();
     // y_cur / ri_prev
     let mut final_result = y_prev.clone();
-    for i in 0..y_prev.degree()+1 {
+    for i in 0..y_prev.degree() + 1 {
         final_result[i] = final_result[i].mul(divisor_inv.unwrap());
     }
     final_result

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -215,7 +215,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
         // TODO: q is just a monomial, then we can optimize the next computation
         (q, ri_cur) = DenseOrSparsePolynomial::from(ri_prev.clone())
             .divide_with_q_and_r(&ri_cur.into())
-            .expect("loop divisor is not zero");
+            .expect("just checked that the loop divisor is not zero");
         ri_prev = ri_aux.into();
         // x_cur = x_prev - q.x_cur
         (x_cur, x_prev) = update_diophantine(x_prev, x_cur, q.clone().into());

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -132,7 +132,8 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
 /// The purpose is to obtain a polynomial with small random coefficients.
 pub fn sample<const MAX_POLY_DEGREE: usize>(mut rng: ThreadRng) -> Poly<MAX_POLY_DEGREE> {
     let mut res = Poly::zero();
-    let max_coeff = 8;
+    // TODO: assert that this is less than the modulus of the coefficient
+    let max_coeff = 6;
     let t = 2;
     for i in 0..MAX_POLY_DEGREE {
         let coeff_rand = rng.gen_range(1..max_coeff);

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -5,6 +5,7 @@
 
 use ark_ff::{Field, One, Zero};
 use ark_poly::polynomial::Polynomial;
+use rand::Rng;
 
 pub use fq::Coeff;
 pub use modular_poly::{
@@ -120,4 +121,19 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
     }
 
     (x_prev, y_prev, ri_prev)
+}
+
+/// This sampling is similar to what will be necessary for YASHE KeyGen
+/// TODO: generate Gaussian distribution instead of "uniform"
+pub fn sample<const MAX_POLY_DEGREE: usize>() -> Poly<MAX_POLY_DEGREE> {
+    let mut rng = rand::thread_rng();
+    let mut res = Poly::zero();
+    let max_coeff = 8;
+    let t = 2;
+    for i in 0..MAX_POLY_DEGREE {
+        let coeff_rand = rng.gen_range(1..max_coeff);
+        res[i] = Coeff::from(t * coeff_rand);
+    }
+    res[0] += Coeff::one();
+    res
 }

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -168,7 +168,7 @@ pub fn inverse(a: &Poly) -> Result<Poly, String> {
     let y = extended_gcd(&mod_pol, a);
     let mul_both = a.clone().mul(y.clone());
     if mul_both.is_one() {
-        Ok(y.into())
+        Ok(y)
     } else {
         Err("No inverse in the ring.".to_owned())
     }
@@ -203,7 +203,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
     // yi+1 = yi-1 - q.yi
     let mut y_aux = y_cur.clone();
     let mul_res_y = y_cur.mul(&q.into());
-    y_cur = y_prev.sub(&mul_res_y.into());
+    y_cur = y_prev.sub(&mul_res_y);
     y_prev = y_aux;
     // loop until ri_cur = 0
     while !(ri_cur.is_zero()) {
@@ -228,7 +228,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
     let divisor_inv = divisor[0].inverse();
     // y_cur / ri_prev
     let mut final_result = y_prev.clone();
-    for i in 0..y_prev.degree() + 1 {
+    for i in 0..=y_prev.degree() {
         final_result[i] = final_result[i].mul(divisor_inv.unwrap());
     }
     final_result

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -223,7 +223,7 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
         (y_cur, y_prev) = update_diophantine(y_prev, y_cur, q.clone().into());
     }
     // compute ri_prev inverse to calculate the final result
-    let mut divisor = ri_prev.clone();
+    let divisor = ri_prev.clone();
     // FIXME: if b is not invertible mod a the assert is not going to pass.
     // Since the test is probabilistic, we have a small chance of failure.
     // It fails after a small number of executions.

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -15,7 +15,6 @@ pub use modular_poly::{
     Poly,
 };
 use std::ops::Mul;
-use rand::Rng;
 
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(not(any(test, feature = "benchmark")))]
@@ -233,19 +232,4 @@ pub fn extended_gcd(a: &Poly, b: &Poly) -> Poly {
         final_result[i] = final_result[i].mul(divisor_inv);
     }
     final_result
-}
-
-/// This sampling is similar to what will be necessary for YASHE KeyGen
-/// TODO: generate Gaussian distribution instead of "uniform"
-pub fn sample() -> Poly {
-    let mut rng = rand::thread_rng();
-    let mut res = Poly::zero();
-    let max_coeff = 8;
-    let t = 2;
-    for i in 0..MAX_POLY_DEGREE {
-        let coeff_rand = rng.gen_range(1..max_coeff);
-        res[i] = Coeff::from(t * coeff_rand);
-    }
-    res[0] += Coeff::one();
-    res
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -19,7 +19,7 @@ use ark_poly::polynomial::univariate::{
 };
 use derive_more::{Add, AsRef, Deref, DerefMut, Div, Into, Neg, Rem};
 
-use crate::primitives::poly::{mod_poly, mul_poly, Coeff};
+use crate::primitives::poly::{mod_poly, mul_poly, new_unreduced_poly_modulus_slow, Coeff};
 
 pub(super) mod modulus;
 pub(super) mod mul;
@@ -147,6 +147,12 @@ impl<const MAX_POLY_DEGREE: usize> Poly<MAX_POLY_DEGREE> {
     }
 
     // Basic Internal Operations
+
+    /// Constructs and returns a new polynomial modulus used for the polynomial field, `X^[MAX_POLY_DEGREE] + 1`.
+    /// This is the canonical but un-reduced form of the modulus, because the reduced form is the zero polynomial.
+    pub fn new_unreduced_poly_modulus_slow() -> Self {
+        new_unreduced_poly_modulus_slow()
+    }
 
     /// Multiplies two polynomials, and returns the result in reduced form.
     ///

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -323,6 +323,24 @@ impl<const MAX_POLY_DEGREE: usize> Mul<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY
     }
 }
 
+impl<const MAX_POLY_DEGREE: usize> Mul for &Poly<MAX_POLY_DEGREE> {
+    type Output = Poly<MAX_POLY_DEGREE>;
+
+    /// Multiplies then reduces by the polynomial modulus.
+    fn mul(self, rhs: Self) -> Self::Output {
+        mul_poly(self, rhs)
+    }
+}
+
+impl<const MAX_POLY_DEGREE: usize> Mul<Poly<MAX_POLY_DEGREE>> for &Poly<MAX_POLY_DEGREE> {
+    type Output = Poly<MAX_POLY_DEGREE>;
+
+    /// Multiplies then reduces by the polynomial modulus.
+    fn mul(self, rhs: Poly<MAX_POLY_DEGREE>) -> Self::Output {
+        mul_poly(self, &rhs)
+    }
+}
+
 impl<const MAX_POLY_DEGREE: usize> Mul<DensePolynomial<Coeff>> for Poly<MAX_POLY_DEGREE> {
     type Output = Self;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -84,6 +84,16 @@ impl<const MAX_POLY_DEGREE: usize> Poly<MAX_POLY_DEGREE> {
         Self(DensePolynomial::naive_mul(self, other))
     }
 
+    // Re-Implement DenseOrSparsePolynomial methods, so the types are all `Poly`
+
+    /// Divide `self`` by another polynomial, and return `(quotient, remainder)`.
+    pub fn divide_with_q_and_r(&self, divisor: &Self) -> Option<(Self, Self)> {
+        let (quotient, remainder) =
+            DenseOrSparsePolynomial::from(self).divide_with_q_and_r(&divisor.into())?;
+
+        Some((quotient.into(), remainder.into()))
+    }
+
     // Efficient Re-Implementations
 
     /// Returns `X^n` as a polynomial in reduced form.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -69,16 +69,12 @@ pub fn mod_poly_manual_ref<const MAX_POLY_DEGREE: usize>(
 pub fn mod_poly_ark_ref_slow<const MAX_POLY_DEGREE: usize>(
     dividend: &Poly<MAX_POLY_DEGREE>,
 ) -> Poly<MAX_POLY_DEGREE> {
-    use ark_poly::polynomial::univariate::DenseOrSparsePolynomial;
-
-    let dividend: DenseOrSparsePolynomial<'_, _> = dividend.into();
-
     // The DenseOrSparsePolynomial implementation ensures canonical form.
     let (_quotient, remainder) = dividend
-        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<MAX_POLY_DEGREE>().into())
+        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<MAX_POLY_DEGREE>())
         .expect("POLY_MODULUS is not zero");
 
-    remainder.into()
+    remainder
 }
 
 /// Reduces `dividend` to `dividend % [POLY_MODULUS]`.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
@@ -1,5 +1,7 @@
 //! Efficient polynomial multiplication.
 
+use std::ops::MulAssign;
+
 use ark_ff::Zero;
 use ark_poly::polynomial::Polynomial;
 use static_assertions::const_assert_eq;
@@ -7,8 +9,26 @@ use static_assertions::const_assert_eq;
 use crate::primitives::poly::{
     mod_poly,
     modular_poly::modulus::{mod_poly_ark_ref_slow, mod_poly_manual_mut},
-    Poly,
+    Coeff, Poly,
 };
+
+// Simple multiplication by a field element.
+
+impl<const MAX_POLY_DEGREE: usize> MulAssign<Coeff> for Poly<MAX_POLY_DEGREE> {
+    fn mul_assign(&mut self, rhs: Coeff) {
+        for coeff in &mut self.0.coeffs {
+            *coeff *= rhs;
+        }
+    }
+}
+
+impl<const MAX_POLY_DEGREE: usize> MulAssign<Coeff> for &mut Poly<MAX_POLY_DEGREE> {
+    fn mul_assign(&mut self, rhs: Coeff) {
+        for coeff in &mut self.0.coeffs {
+            *coeff *= rhs;
+        }
+    }
+}
 
 /// The fastest available cyclotomic polynomial multiplication operation (multiply then reduce).
 pub use rec_karatsuba_mul as mul_poly;

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -151,7 +151,7 @@ impl<const MAX_POLY_DEGREE: usize> SubAssign<&Poly<MAX_POLY_DEGREE>> for Poly<MA
     }
 }
 
-// Multiplying by a polynomial is a trivial wrapper can't increase the degree, so it is trivial.
+// Multiplying by a scalar can't increase the degree, so it is trivial.
 impl<const MAX_POLY_DEGREE: usize> Mul<Coeff> for Poly<MAX_POLY_DEGREE> {
     type Output = Self;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -151,7 +151,7 @@ impl<const MAX_POLY_DEGREE: usize> SubAssign<&Poly<MAX_POLY_DEGREE>> for Poly<MA
     }
 }
 
-// Multiplying by a scalar can't increase the degree, so it is trivial.
+// Multiplying by a polynomial is a trivial wrapper can't increase the degree, so it is trivial.
 impl<const MAX_POLY_DEGREE: usize> Mul<Coeff> for Poly<MAX_POLY_DEGREE> {
     type Output = Self;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -44,7 +44,7 @@ impl Zero for Poly {
 impl One for Poly {
     fn one() -> Self {
         let mut poly = Self::zero();
-        poly.coeffs[0] = Coeff::one();
+        poly[0] = Coeff::one();
         poly
     }
 

--- a/eyelid-match-ops/src/primitives/poly/test.rs
+++ b/eyelid-match-ops/src/primitives/poly/test.rs
@@ -6,5 +6,5 @@ pub mod gen;
 #[cfg(test)]
 pub mod mul;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "benchmark"))]
 pub mod inv;

--- a/eyelid-match-ops/src/primitives/poly/test.rs
+++ b/eyelid-match-ops/src/primitives/poly/test.rs
@@ -6,5 +6,5 @@ pub mod gen;
 #[cfg(test)]
 pub mod mul;
 
-#[cfg(any(test, feature = "benchmark"))]
+#[cfg(test)]
 pub mod inv;

--- a/eyelid-match-ops/src/primitives/poly/test.rs
+++ b/eyelid-match-ops/src/primitives/poly/test.rs
@@ -5,3 +5,6 @@ pub mod gen;
 
 #[cfg(test)]
 pub mod mul;
+
+#[cfg(test)]
+pub mod inv;

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -3,6 +3,8 @@
 use super::super::*;
 use rand::Rng;
 
+/// This sampling is similar to what will be necessary for YASHE KeyGen
+/// TODO: generate Gaussian distribution instead of "uniform"
 fn sample() -> Poly {
     let mut rng = rand::thread_rng();
     let mut res = Poly::zero();
@@ -19,6 +21,9 @@ fn sample() -> Poly {
 #[test]
 fn test_inverse() {
     let f = sample();
+    // REMARK: For our parameter choices it is very likely to find
+    // the inverse in the first attempt.
+    // For small degree and coefficient modulus, the situation may change.
     let out = inverse(&f);
     assert!(out.is_ok());
 }

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,22 +1,6 @@
 //! Tests for polynomial inverse.
 
 use super::super::*;
-use rand::Rng;
-
-/// This sampling is similar to what will be necessary for YASHE KeyGen
-/// TODO: generate Gaussian distribution instead of "uniform"
-fn sample() -> Poly {
-    let mut rng = rand::thread_rng();
-    let mut res = Poly::zero();
-    let max_coeff = 8;
-    let t = 2;
-    for i in 0..MAX_POLY_DEGREE {
-        let coeff_rand = rng.gen_range(1..max_coeff);
-        res[i] = Coeff::from(t * coeff_rand);
-    }
-    res[0] += Coeff::one();
-    res
-}
 
 #[test]
 fn test_inverse() {

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,6 +1,22 @@
 //! Tests for polynomial inverse.
 
 use super::super::*;
+use rand::Rng;
+
+/// This sampling is similar to what will be necessary for YASHE KeyGen
+/// TODO: generate Gaussian distribution instead of "uniform"
+pub fn sample() -> Poly {
+    let mut rng = rand::thread_rng();
+    let mut res = Poly::zero();
+    let max_coeff = 8;
+    let t = 2;
+    for i in 0..MAX_POLY_DEGREE {
+        let coeff_rand = rng.gen_range(1..max_coeff);
+        res[i] = Coeff::from(t * coeff_rand);
+    }
+    res[0] += Coeff::one();
+    res
+}
 
 #[test]
 fn test_inverse() {

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -12,7 +12,8 @@ use ark_poly::Polynomial;
 
 #[test]
 fn test_inverse() {
-    let f = sample::<FULL_RES_POLY_DEGREE>();
+    let rng = rand::thread_rng();
+    let f = sample::<FULL_RES_POLY_DEGREE>(rng);
 
     // REMARK: For our parameter choices it is very likely to find
     // the inverse in the first attempt.

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,21 +1,7 @@
 //! Tests for polynomial inverse.
 
-use super::gen::rand_poly;
-
 use super::super::*;
 use rand::Rng;
-
-/*#[test]
-fn test_extended_gcd() {
-    let mut p1 = rand_poly(MAX_POLY_DEGREE - 1);
-
-    let mut xnm1 = zero_poly(MAX_POLY_DEGREE - 1);
-    xnm1.coeffs[MAX_POLY_DEGREE - 1] = Coeff::one();
-
-    let res = extended_gcd(&xnm1, p1);
-
-    dbg!(res);
-}*/
 
 fn sample() -> Poly {
     let mut rng = rand::thread_rng();
@@ -30,19 +16,14 @@ fn sample() -> Poly {
     res
 }
 
-
 #[test]
 fn test_inverse() {
-    let d = Poly::zero();
-
-    let mut res;
     loop {
         let f = sample();
         let out = inverse(&f);
         if !out.is_err() {
-            res = out.unwrap();
+            out.unwrap();
             break;
         }
-    };
-
+    }
 }

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -18,12 +18,7 @@ fn sample() -> Poly {
 
 #[test]
 fn test_inverse() {
-    loop {
-        let f = sample();
-        let out = inverse(&f);
-        if !out.is_err() {
-            out.unwrap();
-            break;
-        }
-    }
+    let f = sample();
+    let out = inverse(&f);
+    assert!(out.is_ok());
 }

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -3,6 +3,7 @@
 use crate::primitives::poly::sample;
 use ark_ff::{One, Zero};
 
+use crate::primitives::poly::test::gen::rand_poly;
 use crate::primitives::poly::Poly;
 
 #[cfg(test)]
@@ -10,14 +11,10 @@ use crate::primitives::poly::{extended_gcd, inverse, FULL_RES_POLY_DEGREE};
 #[cfg(test)]
 use ark_poly::Polynomial;
 
-#[test]
-fn test_inverse() {
-    let rng = rand::thread_rng();
-    let f = sample::<FULL_RES_POLY_DEGREE>(rng);
-
+fn inverse_test_helper<const MAX_POLY_DEGREE: usize>(f: &Poly<MAX_POLY_DEGREE>) {
     // REMARK: For our parameter choices it is very likely to find
     // the inverse in the first attempt.
-    let out = inverse(&f);
+    let out = inverse(f);
 
     #[cfg(not(tiny_poly))]
     let expect_msg = "unexpected non-invertible large polynomial";
@@ -30,7 +27,7 @@ fn test_inverse() {
         // For small degree and coefficient modulus, non-invertible polynomials are more likely.
 
         // Check that `f` isn't invertible
-        let (_x, y, _d) = extended_gcd(&Poly::new_unreduced_poly_modulus_slow(), &f);
+        let (_x, y, _d) = extended_gcd(&Poly::new_unreduced_poly_modulus_slow(), f);
         let fy = f * y;
 
         // Since `f` is not invertible, `f * y` can't be `1`.
@@ -44,6 +41,22 @@ fn test_inverse() {
             assert_ne!(fy.degree(), 0, "incorrect inverse() impl: the inverse of f was y*(c^1), because f * y is a non-zero constant c");
         }
     }
+}
+
+#[test]
+fn test_inverse_with_small_random_coefficients() {
+    let rng = rand::thread_rng();
+    let f = sample::<FULL_RES_POLY_DEGREE>(rng);
+
+    // REMARK: For our parameter choices it is very likely to find
+    // the inverse in the first attempt.
+    inverse_test_helper(&f);
+}
+
+#[test]
+fn test_inverse_with_random_coefficients() {
+    let f: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    inverse_test_helper(&f);
 }
 
 #[test]

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,29 +1,14 @@
 //! Tests for polynomial inverse.
 
+use crate::primitives::poly::sample;
 use ark_ff::{One, Zero};
-use rand::Rng;
 
-use crate::primitives::poly::{Coeff, Poly};
+use crate::primitives::poly::Poly;
 
 #[cfg(test)]
 use crate::primitives::poly::{extended_gcd, inverse, FULL_RES_POLY_DEGREE};
 #[cfg(test)]
 use ark_poly::Polynomial;
-
-/// This sampling is similar to what will be necessary for YASHE KeyGen
-/// TODO: generate Gaussian distribution instead of "uniform"
-pub fn sample<const MAX_POLY_DEGREE: usize>() -> Poly<MAX_POLY_DEGREE> {
-    let mut rng = rand::thread_rng();
-    let mut res = Poly::zero();
-    let max_coeff = 8;
-    let t = 2;
-    for i in 0..MAX_POLY_DEGREE {
-        let coeff_rand = rng.gen_range(1..max_coeff);
-        res[i] = Coeff::from(t * coeff_rand);
-    }
-    res[0] += Coeff::one();
-    res
-}
 
 #[test]
 fn test_inverse() {

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -26,4 +26,5 @@ fn test_inverse() {
     // For small degree and coefficient modulus, the situation may change.
     let out = inverse(&f);
     assert!(out.is_ok());
+    assert_eq!(f * out.expect("just checked ok"), Poly::one());
 }

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -6,7 +6,9 @@ use rand::Rng;
 use crate::primitives::poly::{Coeff, Poly};
 
 #[cfg(test)]
-use crate::primitives::poly::{inverse, FULL_RES_POLY_DEGREE};
+use crate::primitives::poly::{extended_gcd, inverse, FULL_RES_POLY_DEGREE};
+#[cfg(test)]
+use ark_poly::Polynomial;
 
 /// This sampling is similar to what will be necessary for YASHE KeyGen
 /// TODO: generate Gaussian distribution instead of "uniform"
@@ -26,10 +28,34 @@ pub fn sample<const MAX_POLY_DEGREE: usize>() -> Poly<MAX_POLY_DEGREE> {
 #[test]
 fn test_inverse() {
     let f = sample::<FULL_RES_POLY_DEGREE>();
+
     // REMARK: For our parameter choices it is very likely to find
     // the inverse in the first attempt.
-    // For small degree and coefficient modulus, the situation may change.
     let out = inverse(&f);
-    assert!(out.is_ok());
-    assert_eq!(f * out.expect("just checked ok"), Poly::one());
+
+    #[cfg(not(tiny_poly))]
+    let expect_msg = "unexpected non-invertible large polynomial";
+    #[cfg(tiny_poly)]
+    let expect_msg = "just checked ok";
+
+    if !cfg!(tiny_poly) || out.is_ok() {
+        assert_eq!(f * out.expect(expect_msg), Poly::one());
+    } else {
+        // For small degree and coefficient modulus, non-invertible polynomials are more likely.
+
+        // Check that `f` isn't invertible
+        let (_x, y, _d) = extended_gcd(&Poly::new_unreduced_poly_modulus_slow(), &f);
+        let fy = f * y;
+
+        // Since `f` is not invertible, `f * y` can't be `1`.
+        assert_ne!(
+            fy,
+            Poly::one(),
+            "incorrect inverse() impl: the inverse of f was y, because f * y == 1"
+        );
+        // Since all non-zero `Coeff` values *are* invertible in the integer field, `f * y` can't be a constant, either.
+        if fy != Poly::zero() {
+            assert_ne!(fy.degree(), 0, "incorrect inverse() impl: the inverse of f was y*(c^1), because f * y is a non-zero constant c");
+        }
+    }
 }

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -59,3 +59,22 @@ fn test_inverse() {
         }
     }
 }
+
+#[test]
+fn test_edge_cases() {
+    // Inverse of one is one
+    let one_poly: Poly<FULL_RES_POLY_DEGREE> = Poly::one();
+    let mut out = inverse(&one_poly.clone());
+    assert_eq!(out, Ok(one_poly.clone()));
+
+    // Inverse of minus one is minus one
+    let zero_poly: Poly<FULL_RES_POLY_DEGREE> = Poly::zero();
+    let minus_one_poly = zero_poly - one_poly.clone();
+    out = inverse(&minus_one_poly.clone());
+    assert_eq!(out, Ok(minus_one_poly));
+
+    // Inverse of zero is error
+    let zero_poly: Poly<FULL_RES_POLY_DEGREE> = Poly::zero();
+    out = inverse(&zero_poly.clone());
+    assert!(out.is_err());
+}

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,0 +1,17 @@
+//! Tests for polynomial inverse.
+
+use super::gen::rand_poly;
+
+use super::super::*;
+
+#[test]
+fn test_extended_gcd() {
+    let mut p1 = rand_poly(MAX_POLY_DEGREE - 1);
+
+    let mut xnm1 = zero_poly(MAX_POLY_DEGREE - 1);
+    xnm1.coeffs[MAX_POLY_DEGREE - 1] = Coeff::one();
+
+    let res = extended_gcd(&xnm1, p1);
+
+    dbg!(res);
+}

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -1,7 +1,7 @@
 //! Tests for polynomial multiplication.
 
 use ark_ff::{One, Zero};
-use ark_poly::{univariate::DenseOrSparsePolynomial, Polynomial};
+use ark_poly::Polynomial;
 
 use crate::primitives::poly::{
     flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
@@ -63,18 +63,16 @@ where
 {
     // X^MAX_POLY_DEGREE
     //
-    // Since the degree is equal to MAX_POLY_DEGREE, this is not reduced.
+    // Create a polynomial with degree equal to MAX_POLY_DEGREE.
+    // We can't use the standard methods, because we want an un-reduced polynomial.
     // But it is in canonical form, because the leading coefficient is non-zero.
     let mut x_max: Poly<MAX_POLY_DEGREE> = Poly::zero();
     x_max[MAX_POLY_DEGREE] = Coeff::one();
 
     // Manually calculate the reduced representation of X^N as the constant `MODULUS - 1`.
-    let x_max = DenseOrSparsePolynomial::from(x_max);
     let (q, x_max) = x_max
-        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<MAX_POLY_DEGREE>().into())
+        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<MAX_POLY_DEGREE>())
         .expect("is divisible by X^MAX_POLY_DEGREE");
-    let q: Poly<MAX_POLY_DEGREE> = q.into();
-    let x_max: Poly<MAX_POLY_DEGREE> = x_max.into();
 
     assert_eq!(q, Poly::from_coefficients_vec(vec![Coeff::one()]));
     assert_eq!(


### PR DESCRIPTION
This PR adds the Extended GCD for cyclotomic polynomials. Inverses can be computed using this primitive. For our parameters choices we have high probability of finding an invertible element for relatively small randomly sampled polynomials. Therefore we don't expect to sample multiple times before finding an invertible element. This is compatible  with experiments carried out in the C++ [repo](https://github.com/Inversed-Tech/hom-ham/tree/main/si-ntru). 

This is efficient enough to be used for key generation of the YASHE construction. 

Closes #10 