### PR TITLE
Give permissions for performance comments on commits

### DIFF
--- a/.github/workflows/ci-bench-changes.yml
+++ b/.github/workflows/ci-bench-changes.yml
@@ -27,9 +27,9 @@ env:
   RUST_LIB_BACKTRACE: ${{ vars.RUST_BACKTRACE_BENCHMARKS }}
 
 permissions:
-  # When we enable performance graphs (#53):
-  # Writing results to the gh-pages branch
-  #contents: write
+  # Leaving performance comments on commits.
+  # And later, writing results to the gh-pages branch (#53).
+  contents: write
   # Performance comments on PRs
   pull-requests: write
 


### PR DESCRIPTION
This is a CI bug fix to allow performance comments on commits. (Not just the PRs that were merged to create the commit.)