### PR TITLE
Add YASHE key generation and full iris bit length polynomial benchmarks

### DIFF
--- a/.github/workflows/ci-bench-changes.yml
+++ b/.github/workflows/ci-bench-changes.yml
@@ -52,7 +52,7 @@ jobs:
        run: |
          export RUSTFLAGS="-D warnings"
          echo "Warning: benchmark timings are unreliable in CI due to virtualization"
-         cargo bench --features benchmark -- 'match|multiplication|inv' --output-format bencher | tee output.txt
+         cargo bench --features benchmark -- 'match|multiplication|inv|keygen' --output-format bencher | tee output.txt
          echo "Warning: benchmark timings are unreliable in CI due to virtualization"
 
      # Download previous benchmark result from the most recent `main` branch cache (if any exists).

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -319,7 +319,7 @@ pub fn bench_mod_poly_ark(settings: &mut Criterion) {
 pub fn bench_inv(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
 
-    let rng = rand::thread_rng();
+    let mut rng = rand::thread_rng();
 
     let params = YasheParams {
         t: 1024,
@@ -327,7 +327,7 @@ pub fn bench_inv(settings: &mut Criterion) {
     };
     let ctx: Yashe<FULL_RES_POLY_DEGREE> = Yashe::new(params);
 
-    let p = ctx.sample_gaussian(rng);
+    let p = ctx.sample_gaussian(&mut rng);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -348,7 +348,7 @@ pub fn bench_inv(settings: &mut Criterion) {
 pub fn bench_inv_iris(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
 
-    let rng = rand::thread_rng();
+    let mut rng = rand::thread_rng();
 
     let params = YasheParams {
         t: 1024,
@@ -356,7 +356,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
     };
     let ctx: Yashe<IRIS_BIT_LENGTH> = Yashe::new(params);
 
-    let p = ctx.sample_gaussian(rng);
+    let p = ctx.sample_gaussian(&mut rng);
 
     settings.bench_with_input(
         BenchmarkId::new(

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -8,7 +8,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use eyelid_match_ops::{
-    IRIS_BIT_LENGTH,
     plaintext::{
         self,
         test::gen::{random_iris_code, random_iris_mask},
@@ -19,6 +18,7 @@ use eyelid_match_ops::{
         },
         yashe::{Yashe, YasheParams},
     },
+    IRIS_BIT_LENGTH,
 };
 
 // Configure Criterion:
@@ -81,7 +81,6 @@ criterion_group! {
     // List iris-length polynomial inverse implementations here.
     targets = bench_inv_iris
 }
-
 
 // List groups here.
 criterion_main!(
@@ -305,7 +304,13 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
 
     let rng = rand::thread_rng();
 
-    let p = sample::<IRIS_BIT_LENGTH>(rng);
+    let params = YasheParams {
+        t: 1024,
+        delta: 3.2,
+    };
+    let ctx: Yashe<IRIS_BIT_LENGTH> = Yashe::new(params);
+
+    let p = ctx.sample_gaussian(rng);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -316,7 +321,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
         |benchmark, p| {
             benchmark.iter_with_large_drop(|| {
                 // To avoid timing dropping the return value, this line must not end in ';'
-                poly::inverse(p)
+                inverse(p)
             })
         },
     );

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -79,7 +79,7 @@ criterion_group! {
 criterion_group! {
     name = bench_cyclotomic_multiplication_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(30));
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(40));
     // List iris-length polynomial multiplication implementations here.
     targets = bench_naive_cyclotomic_mul_iris, bench_rec_karatsuba_mul_iris, bench_flat_karatsuba_mul_iris
 }
@@ -87,7 +87,7 @@ criterion_group! {
 criterion_group! {
     name = bench_inverse_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(60));
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(120));
     // List iris-length polynomial inverse implementations here.
     targets = bench_inv_iris
 }
@@ -95,7 +95,7 @@ criterion_group! {
 criterion_group! {
     name = bench_key_generation_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(130));
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(230));
     // List key generation implementations here.
     targets = bench_keygen_iris
 }
@@ -135,11 +135,6 @@ fn bench_plaintext_full_match(settings: &mut Criterion) {
 
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data.
 pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
-    // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group("Slow Benchmarks");
-    // We can override the configuration on a per-group level
-    settings.sampling_mode(Flat);
-
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
     let p2: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
@@ -161,6 +156,11 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
 
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
+    // Tweak configuration for a long-running test
+    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    // We can override the configuration on a per-group level
+    settings.sampling_mode(Flat);
+
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
     let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
@@ -203,6 +203,11 @@ pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
 
 /// Run [`poly::rec_karatsuba_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
+    // Tweak configuration for a long-running test
+    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    // We can override the configuration on a per-group level
+    settings.sampling_mode(Flat);
+
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
     let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -34,7 +34,7 @@ criterion_group! {
 criterion_group! {
     name = bench_cyclotomic_multiplication;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(50);
+    config = Criterion::default().sample_size(10);
     // List cyclotomic multiplication implementations here.
     targets = bench_naive_cyclotomic_mul, bench_rec_karatsuba_mul, bench_flat_karatsuba_mul
 }
@@ -58,7 +58,7 @@ criterion_group! {
 criterion_group! {
     name = bench_inverse;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default();
+    config = Criterion::default().sample_size(20);
     // List polynomial inverse implementations here.
     targets = bench_inv
 }
@@ -69,15 +69,16 @@ criterion_group! {
 criterion_group! {
     name = bench_cyclotomic_multiplication_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default();
+    config = Criterion::default().sample_size(30);
     // List iris-length polynomial multiplication implementations here.
+    // Currently we only benchmark the most efficient implementation.
     targets = bench_rec_karatsuba_mul_iris
 }
 
 criterion_group! {
     name = bench_inverse_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default();
+    config = Criterion::default().sample_size(10);
     // List iris-length polynomial inverse implementations here.
     targets = bench_inv_iris
 }
@@ -88,7 +89,9 @@ criterion_main!(
     bench_cyclotomic_multiplication,
     bench_poly_split_karatsuba,
     bench_polynomial_modulus,
-    bench_inverse
+    bench_inverse,
+    bench_cyclotomic_multiplication_iris,
+    bench_inverse_iris
 );
 
 /// Run [`plaintext::is_iris_match()`] as a Criterion benchmark with random data.

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -5,6 +5,8 @@
 // TODO: move the macros to a separate module and allow missing docs only in that module.
 #![allow(missing_docs)]
 
+use std::time::Duration;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use eyelid_match_ops::{
@@ -69,7 +71,7 @@ criterion_group! {
 criterion_group! {
     name = bench_cyclotomic_multiplication_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(30));
     // List iris-length polynomial multiplication implementations here.
     targets = bench_naive_cyclotomic_mul_iris, bench_rec_karatsuba_mul_iris, bench_flat_karatsuba_mul_iris
 }
@@ -77,7 +79,7 @@ criterion_group! {
 criterion_group! {
     name = bench_inverse_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(80));
     // List iris-length polynomial inverse implementations here.
     targets = bench_inv_iris
 }

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -69,10 +69,9 @@ criterion_group! {
 criterion_group! {
     name = bench_cyclotomic_multiplication_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(30);
+    config = Criterion::default().sample_size(10);
     // List iris-length polynomial multiplication implementations here.
-    // Currently we only benchmark the most efficient implementation.
-    targets = bench_rec_karatsuba_mul_iris
+    targets = bench_naive_cyclotomic_mul_iris, bench_rec_karatsuba_mul_iris, bench_flat_karatsuba_mul_iris
 }
 
 criterion_group! {
@@ -124,6 +123,27 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
         BenchmarkId::new(
             "Cyclotomic multiplication: polynomial",
             "2 random polys of degree N",
+        ),
+        &(p1, p2),
+        |benchmark, (p1, p2)| {
+            benchmark.iter_with_large_drop(|| {
+                // To avoid timing dropping the return value, this line must not end in ';'
+                poly::naive_cyclotomic_mul(p1, p2)
+            })
+        },
+    );
+}
+
+/// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
+pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
+    // Setup: generate random cyclotomic polynomials
+    let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+    let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+
+    settings.bench_with_input(
+        BenchmarkId::new(
+            "Cyclotomic multiplication: polynomial",
+            "2 random polys of degree IRIS_BIT_LENGTH",
         ),
         &(p1, p2),
         |benchmark, (p1, p2)| {
@@ -187,6 +207,27 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
         BenchmarkId::new(
             "Flat Karatsuba multiplication: polynomial",
             "2 random polys of degree N",
+        ),
+        &(p1, p2),
+        |benchmark, (p1, p2)| {
+            benchmark.iter_with_large_drop(|| {
+                // To avoid timing dropping the return value, this line must not end in ';'
+                poly::flat_karatsuba_mul(p1, p2)
+            })
+        },
+    );
+}
+
+/// Run [`poly::flat_karatsuba_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
+pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
+    // Setup: generate random cyclotomic polynomials
+    let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+    let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+
+    settings.bench_with_input(
+        BenchmarkId::new(
+            "Flat Karatsuba multiplication: polynomial",
+            "2 random polys of degree IRIS_BIT_LENGTH",
         ),
         &(p1, p2),
         |benchmark, (p1, p2)| {

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode::*};
 
 use eyelid_match_ops::{
     plaintext::{
@@ -87,7 +87,7 @@ criterion_group! {
 criterion_group! {
     name = bench_inverse_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(80));
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(60));
     // List iris-length polynomial inverse implementations here.
     targets = bench_inv_iris
 }
@@ -95,7 +95,7 @@ criterion_group! {
 criterion_group! {
     name = bench_key_generation_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(130));
     // List key generation implementations here.
     targets = bench_keygen_iris
 }
@@ -135,6 +135,11 @@ fn bench_plaintext_full_match(settings: &mut Criterion) {
 
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data.
 pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
+    // Tweak configuration for a long-running test
+    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    // We can override the configuration on a per-group level
+    settings.sampling_mode(Flat);
+
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
     let p2: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
@@ -240,6 +245,11 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
 
 /// Run [`poly::flat_karatsuba_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
+    // Tweak configuration for a long-running test
+    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    // We can override the configuration on a per-group level
+    settings.sampling_mode(Flat);
+
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
     let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
@@ -366,6 +376,11 @@ pub fn bench_inv(settings: &mut Criterion) {
 
 /// Run [`poly::inverse()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_inv_iris(settings: &mut Criterion) {
+    // Tweak configuration for a long-running test
+    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    // We can override the configuration on a per-group level
+    settings.sampling_mode(Flat);
+
     // Setup: generate random cyclotomic polynomials
 
     let mut rng = rand::thread_rng();
@@ -421,6 +436,11 @@ pub fn bench_keygen(settings: &mut Criterion) {
 
 /// Run [`Yashe::keygen()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_keygen_iris(settings: &mut Criterion) {
+    // Tweak configuration for a long-running test
+    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    // We can override the configuration on a per-group level
+    settings.sampling_mode(Flat);
+
     // Setup parameters
     let params = YasheParams {
         t: 1024,

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -372,3 +372,48 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
         },
     );
 }
+
+/// Run [`Yashe::keygen()`] as a Criterion benchmark with random data.
+pub fn bench_keygen(settings: &mut Criterion) {
+    // Setup parameters
+    let params = YasheParams {
+        t: 1024,
+        delta: 3.2,
+    };
+    let ctx: Yashe<FULL_RES_POLY_DEGREE> = Yashe::new(params);
+
+    settings.bench_with_input(
+        BenchmarkId::new("YASHE keygen", "standard parameters with degree N"),
+        &ctx,
+        |benchmark, ctx| {
+            benchmark.iter_with_large_drop(|| {
+                // To avoid timing dropping the return value, this line must not end in ';'
+                ctx.keygen(&mut rand::thread_rng())
+            })
+        },
+    );
+}
+
+/// Run [`Yashe::keygen()`] as a Criterion benchmark with random data on the full number of iris bits.
+pub fn bench_keygen_iris(settings: &mut Criterion) {
+    // Setup parameters
+    let params = YasheParams {
+        t: 1024,
+        delta: 3.2,
+    };
+    let ctx: Yashe<IRIS_BIT_LENGTH> = Yashe::new(params);
+
+    settings.bench_with_input(
+        BenchmarkId::new(
+            "YASHE keygen",
+            "standard parameters with degree IRIS_BIT_LENGTH",
+        ),
+        &ctx,
+        |benchmark, ctx| {
+            benchmark.iter_with_large_drop(|| {
+                // To avoid timing dropping the return value, this line must not end in ';'
+                ctx.keygen(&mut rand::thread_rng())
+            })
+        },
+    );
+}

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -50,14 +50,14 @@ fn inverse_test_helper<const MAX_POLY_DEGREE: usize>(f: &Poly<MAX_POLY_DEGREE>) 
 
 #[test]
 fn test_key_generation_and_inverse() {
-    let rng = rand::thread_rng();
+    let mut rng = rand::thread_rng();
 
     let params = YasheParams {
         t: 1024,
         delta: 3.2,
     };
     let ctx: Yashe<FULL_RES_POLY_DEGREE> = Yashe::new(params);
-    let f = ctx.sample_gaussian(rng);
+    let f = ctx.sample_gaussian(&mut rng);
 
     // REMARK: For our parameter choices it is very likely to find
     // the inverse in the first attempt.

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -11,13 +11,13 @@ use ark_poly::Polynomial;
 fn keygen_helper<const MAX_POLY_DEGREE: usize>() {
     // TODO: how to deal with different sets of parameters?
     // We must be able to test all the different parameterizations
-    let rng = rand::thread_rng();
+    let mut rng = rand::thread_rng();
     let params = YasheParams {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<MAX_POLY_DEGREE> = Yashe::new(params.clone());
-    let (private_key, public_key) = ctx.keygen(rng);
+    let ctx: Yashe<MAX_POLY_DEGREE> = Yashe::new(params);
+    let (private_key, public_key) = ctx.keygen(&mut rng);
 
     let f_inv = inverse(&private_key.f);
     let priv_key_inv = inverse(&private_key.priv_key);


### PR DESCRIPTION
The YASHE key generation benchmarks stop key generation accidentally getting really slow.

The iris benchmarks provide an upper bound for the performance of iris operations. They also help us work out how our operation speed changes with increasing polynomial size, so we can decide if we need smaller or larger polynomial sizes.

This PR also fixes some method arguments so they can be used in benchmarks, and removes some redundant clones.

Close #54
Close #72 