### PR TITLE
Make the const generic degree into a generic trait struct

### DIFF
--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -273,7 +273,7 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(|| -> (Poly<TestRes>, Poly<TestRes>) {
-                poly::poly_split_half(p, FULL_RES_POLY_DEGREE)
+                poly::poly_split_half(p, TestRes::MAX_POLY_DEGREE)
             })
         },
     );

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -133,8 +133,8 @@ fn bench_plaintext_full_match(settings: &mut Criterion) {
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data.
 pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
-    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p1: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
+    let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -178,8 +178,8 @@ pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
 /// Run [`poly::rec_karatsuba_mul()`] as a Criterion benchmark with random data.
 pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
-    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p1: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
+    let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -221,8 +221,8 @@ pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
 /// Run [`poly::flat_karatsuba_mul()`] as a Criterion benchmark with random data.
 pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
-    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p1: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
+    let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -265,7 +265,7 @@ pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
 /// Run [`poly::poly_split_half()`] as a Criterion benchmark with random data.
 pub fn bench_poly_split_half(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new("Karatsuba: poly split half", "random poly of degree N"),
@@ -282,7 +282,7 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
 /// Run [`poly::poly_split(_, 2)`] as a Criterion benchmark with random data.
 pub fn bench_poly_split_2(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new("Karatsuba: poly split 2", "random poly of degree N"),
@@ -297,7 +297,7 @@ pub fn bench_poly_split_2(settings: &mut Criterion) {
 /// Run [`poly::mod_poly_manual_mut()`] as a Criterion benchmark with random data.
 pub fn bench_mod_poly_manual(settings: &mut Criterion) {
     // Setup: generate a random cyclotomic polynomial the size of a typical multiplication.
-    let dividend: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE * 2);
+    let dividend: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE * 2);
 
     settings.bench_with_input(
         BenchmarkId::new("Manual polynomial modulus", "A random poly of degree 2N"),
@@ -320,7 +320,7 @@ pub fn bench_mod_poly_manual(settings: &mut Criterion) {
 /// Run [`poly::mod_poly_ark_ref_slow()`] as a Criterion benchmark with random data.
 pub fn bench_mod_poly_ark(settings: &mut Criterion) {
     // Setup: generate a random cyclotomic polynomial the size of a typical multiplication.
-    let dividend: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE * 2);
+    let dividend: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE * 2);
 
     settings.bench_with_input(
         BenchmarkId::new("ark-poly polynomial modulus", "A random poly of degree 2N"),

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -348,7 +348,9 @@ pub fn bench_mod_poly_ark(settings: &mut Criterion) {
     );
 }
 
-/// Run [`poly::inverse()`] as a Criterion benchmark with random data.
+/// Run [`poly::inverse()`] as a Criterion benchmark with gaussian random data.
+///
+/// TODO: consider benchmarking the inverse of a uniform random polynomial as well
 pub fn bench_inv(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
 
@@ -370,14 +372,14 @@ pub fn bench_inv(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Result<Poly<FULL_RES_POLY_DEGREE>, String> {
-                p.inverse()
-            })
+            benchmark.iter_with_large_drop(
+                || -> Result<Poly<FULL_RES_POLY_DEGREE>, &'static str> { p.inverse() },
+            )
         },
     );
 }
 
-/// Run [`poly::inverse()`] as a Criterion benchmark with random data on the full number of iris bits.
+/// Run [`poly::inverse()`] as a Criterion benchmark with gaussian random data on the full number of iris bits.
 pub fn bench_inv_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
     let mut settings = settings.benchmark_group("Slow Benchmarks");
@@ -404,8 +406,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Result<Poly<IRIS_BIT_LENGTH>, String> {
-                // TODO: consider benchmarking the inverse of a uniform random polynomial as well
+            benchmark.iter_with_large_drop(|| -> Result<Poly<IRIS_BIT_LENGTH>, &'static str> {
                 p.inverse()
             })
         },

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -134,8 +134,8 @@ fn bench_plaintext_full_match(settings: &mut Criterion) {
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data.
 pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
-    let p2: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -145,7 +145,7 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<FULL_RES_POLY_DEGREE> {
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
                 poly::naive_cyclotomic_mul(p1, p2)
             })
         },
@@ -181,8 +181,8 @@ pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
 /// Run [`poly::rec_karatsuba_mul()`] as a Criterion benchmark with random data.
 pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
-    let p2: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -192,7 +192,7 @@ pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<FULL_RES_POLY_DEGREE> {
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
                 poly::rec_karatsuba_mul(p1, p2)
             })
         },
@@ -228,8 +228,8 @@ pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
 /// Run [`poly::flat_karatsuba_mul()`] as a Criterion benchmark with random data.
 pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
-    let p2: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -239,7 +239,7 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<FULL_RES_POLY_DEGREE> {
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
                 poly::flat_karatsuba_mul(p1, p2)
             })
         },
@@ -275,7 +275,7 @@ pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
 /// Run [`poly::poly_split_half()`] as a Criterion benchmark with random data.
 pub fn bench_poly_split_half(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new("Karatsuba: poly split half", "random poly of degree N"),
@@ -283,7 +283,7 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(
-                || -> (Poly<FULL_RES_POLY_DEGREE>, Poly<FULL_RES_POLY_DEGREE>) {
+                || -> (Poly<TestRes>, Poly<FULL_RES_POLY_DEGREE>) {
                     poly::poly_split_half(p, FULL_RES_POLY_DEGREE)
                 },
             )
@@ -294,14 +294,14 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
 /// Run [`poly::poly_split(_, 2)`] as a Criterion benchmark with random data.
 pub fn bench_poly_split_2(settings: &mut Criterion) {
     // Setup: generate random cyclotomic polynomials
-    let p: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    let p: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new("Karatsuba: poly split 2", "random poly of degree N"),
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Vec<Poly<FULL_RES_POLY_DEGREE>> {
+            benchmark.iter_with_large_drop(|| -> Vec<Poly<TestRes>> {
                 poly::poly_split(p, 2)
             })
         },
@@ -311,14 +311,14 @@ pub fn bench_poly_split_2(settings: &mut Criterion) {
 /// Run [`poly::mod_poly_manual_mut()`] as a Criterion benchmark with random data.
 pub fn bench_mod_poly_manual(settings: &mut Criterion) {
     // Setup: generate a random cyclotomic polynomial the size of a typical multiplication.
-    let dividend: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE * 2);
+    let dividend: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE * 2);
 
     settings.bench_with_input(
         BenchmarkId::new("Manual polynomial modulus", "A random poly of degree 2N"),
         &dividend,
         |benchmark, dividend| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<FULL_RES_POLY_DEGREE> {
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
                 // TODO: work out how to avoid timing this clone
                 // (The production code already avoids cloning where possible.)
                 let mut dividend = dividend.clone();
@@ -334,14 +334,14 @@ pub fn bench_mod_poly_manual(settings: &mut Criterion) {
 /// Run [`poly::mod_poly_ark_ref_slow()`] as a Criterion benchmark with random data.
 pub fn bench_mod_poly_ark(settings: &mut Criterion) {
     // Setup: generate a random cyclotomic polynomial the size of a typical multiplication.
-    let dividend: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE * 2);
+    let dividend: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE * 2);
 
     settings.bench_with_input(
         BenchmarkId::new("ark-poly polynomial modulus", "A random poly of degree 2N"),
         &dividend,
         |benchmark, dividend| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<FULL_RES_POLY_DEGREE> {
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
                 poly::mod_poly_ark_ref_slow(dividend)
             })
         },
@@ -360,7 +360,7 @@ pub fn bench_inv(settings: &mut Criterion) {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<FULL_RES_POLY_DEGREE> = Yashe::new(params);
+    let ctx: Yashe<TestRes> = Yashe::new(params);
 
     let p = ctx.sample_gaussian(&mut rng);
 
@@ -373,7 +373,7 @@ pub fn bench_inv(settings: &mut Criterion) {
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(
-                || -> Result<Poly<FULL_RES_POLY_DEGREE>, &'static str> { p.inverse() },
+                || -> Result<Poly<TestRes>, &'static str> { p.inverse() },
             )
         },
     );
@@ -420,7 +420,7 @@ pub fn bench_keygen(settings: &mut Criterion) {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<FULL_RES_POLY_DEGREE> = Yashe::new(params);
+    let ctx: Yashe<TestRes> = Yashe::new(params);
 
     settings.bench_with_input(
         BenchmarkId::new("YASHE keygen", "standard parameters with degree N"),
@@ -428,7 +428,7 @@ pub fn bench_keygen(settings: &mut Criterion) {
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(
-                || -> (yashe::PrivateKey<FULL_RES_POLY_DEGREE>, yashe::PublicKey<FULL_RES_POLY_DEGREE>) {
+                || -> (yashe::PrivateKey<TestRes>, yashe::PublicKey<FULL_RES_POLY_DEGREE>) {
                     // The thread_rng() call is efficient, because it only clones a small amount of memory,
                     // which is dedicated to the current thread.
                     ctx.keygen(&mut rand::thread_rng())

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -15,9 +15,7 @@ use eyelid_match_ops::{
         test::gen::{random_iris_code, random_iris_mask},
     },
     primitives::{
-        poly::{
-            self, modular_poly::inv::inverse, test::gen::rand_poly, Poly, FULL_RES_POLY_DEGREE,
-        },
+        poly::{self, test::gen::rand_poly, Poly, FULL_RES_POLY_DEGREE},
         yashe::{self, Yashe, YasheParams},
     },
     IRIS_BIT_LENGTH,
@@ -373,7 +371,7 @@ pub fn bench_inv(settings: &mut Criterion) {
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(|| -> Result<Poly<FULL_RES_POLY_DEGREE>, String> {
-                inverse(p)
+                p.inverse()
             })
         },
     );
@@ -408,7 +406,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(|| -> Result<Poly<IRIS_BIT_LENGTH>, String> {
                 // TODO: consider benchmarking the inverse of a uniform random polynomial as well
-                inverse(p)
+                p.inverse()
             })
         },
     );

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -15,10 +15,9 @@ use eyelid_match_ops::{
         test::gen::{random_iris_code, random_iris_mask},
     },
     primitives::{
-        poly::{self, test::gen::rand_poly, IrisBits, Poly, TestRes, FULL_RES_POLY_DEGREE},
+        poly::{self, test::gen::rand_poly, IrisBits, Poly, PolyConf, TestRes},
         yashe::{self, Yashe, YasheParams},
     },
-    IRIS_BIT_LENGTH,
 };
 
 // Configure Criterion:
@@ -170,9 +169,8 @@ pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> {
-                poly::naive_cyclotomic_mul(p1, p2)
-            })
+            benchmark
+                .iter_with_large_drop(|| -> Poly<IrisBits> { poly::naive_cyclotomic_mul(p1, p2) })
         },
     );
 }
@@ -215,9 +213,7 @@ pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> {
-                poly::rec_karatsuba_mul(p1, p2)
-            })
+            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> { poly::rec_karatsuba_mul(p1, p2) })
         },
     );
 }
@@ -260,9 +256,8 @@ pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> {
-                poly::flat_karatsuba_mul(p1, p2)
-            })
+            benchmark
+                .iter_with_large_drop(|| -> Poly<IrisBits> { poly::flat_karatsuba_mul(p1, p2) })
         },
     );
 }
@@ -277,7 +272,7 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> (Poly<TestRes>, Poly<FULL_RES_POLY_DEGREE>) {
+            benchmark.iter_with_large_drop(|| -> (Poly<TestRes>, Poly<TestRes>) {
                 poly::poly_split_half(p, FULL_RES_POLY_DEGREE)
             })
         },
@@ -395,9 +390,8 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Result<Poly<IrisBits>, &'static str> {
-                p.inverse()
-            })
+            benchmark
+                .iter_with_large_drop(|| -> Result<Poly<IrisBits>, &'static str> { p.inverse() })
         },
     );
 }
@@ -417,7 +411,7 @@ pub fn bench_keygen(settings: &mut Criterion) {
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(
-                || -> (yashe::PrivateKey<TestRes>, yashe::PublicKey<FULL_RES_POLY_DEGREE>) {
+                || -> (yashe::PrivateKey<TestRes>, yashe::PublicKey<TestRes>) {
                     // The thread_rng() call is efficient, because it only clones a small amount of memory,
                     // which is dedicated to the current thread.
                     ctx.keygen(&mut rand::thread_rng())
@@ -450,7 +444,7 @@ pub fn bench_keygen_iris(settings: &mut Criterion) {
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(
-                || -> (yashe::PrivateKey<IrisBits>, yashe::PublicKey<IRIS_BIT_LENGTH>) {
+                || -> (yashe::PrivateKey<IrisBits>, yashe::PublicKey<IrisBits>) {
                     ctx.keygen(&mut rand::thread_rng())
                 },
             )

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -15,7 +15,7 @@ use eyelid_match_ops::{
         test::gen::{random_iris_code, random_iris_mask},
     },
     primitives::{
-        poly::{self, test::gen::rand_poly, Poly, FULL_RES_POLY_DEGREE},
+        poly::{self, test::gen::rand_poly, IrisBits, Poly, TestRes, FULL_RES_POLY_DEGREE},
         yashe::{self, Yashe, YasheParams},
     },
     IRIS_BIT_LENGTH,
@@ -145,9 +145,8 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
-                poly::naive_cyclotomic_mul(p1, p2)
-            })
+            benchmark
+                .iter_with_large_drop(|| -> Poly<TestRes> { poly::naive_cyclotomic_mul(p1, p2) })
         },
     );
 }
@@ -192,9 +191,7 @@ pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
-                poly::rec_karatsuba_mul(p1, p2)
-            })
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> { poly::rec_karatsuba_mul(p1, p2) })
         },
     );
 }
@@ -239,9 +236,7 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
-                poly::flat_karatsuba_mul(p1, p2)
-            })
+            benchmark.iter_with_large_drop(|| -> Poly<TestRes> { poly::flat_karatsuba_mul(p1, p2) })
         },
     );
 }
@@ -282,11 +277,9 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(
-                || -> (Poly<TestRes>, Poly<FULL_RES_POLY_DEGREE>) {
-                    poly::poly_split_half(p, FULL_RES_POLY_DEGREE)
-                },
-            )
+            benchmark.iter_with_large_drop(|| -> (Poly<TestRes>, Poly<FULL_RES_POLY_DEGREE>) {
+                poly::poly_split_half(p, FULL_RES_POLY_DEGREE)
+            })
         },
     );
 }
@@ -301,9 +294,7 @@ pub fn bench_poly_split_2(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Vec<Poly<TestRes>> {
-                poly::poly_split(p, 2)
-            })
+            benchmark.iter_with_large_drop(|| -> Vec<Poly<TestRes>> { poly::poly_split(p, 2) })
         },
     );
 }
@@ -341,9 +332,8 @@ pub fn bench_mod_poly_ark(settings: &mut Criterion) {
         &dividend,
         |benchmark, dividend| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<TestRes> {
-                poly::mod_poly_ark_ref_slow(dividend)
-            })
+            benchmark
+                .iter_with_large_drop(|| -> Poly<TestRes> { poly::mod_poly_ark_ref_slow(dividend) })
         },
     );
 }
@@ -372,9 +362,8 @@ pub fn bench_inv(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(
-                || -> Result<Poly<TestRes>, &'static str> { p.inverse() },
-            )
+            benchmark
+                .iter_with_large_drop(|| -> Result<Poly<TestRes>, &'static str> { p.inverse() })
         },
     );
 }

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -159,8 +159,8 @@ pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
     settings.sampling_mode(Flat);
 
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
-    let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+    let p1: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
+    let p2: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -170,7 +170,7 @@ pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<IRIS_BIT_LENGTH> {
+            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> {
                 poly::naive_cyclotomic_mul(p1, p2)
             })
         },
@@ -204,8 +204,8 @@ pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
     settings.sampling_mode(Flat);
 
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
-    let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+    let p1: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
+    let p2: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -215,7 +215,7 @@ pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<IRIS_BIT_LENGTH> {
+            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> {
                 poly::rec_karatsuba_mul(p1, p2)
             })
         },
@@ -249,8 +249,8 @@ pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
     settings.sampling_mode(Flat);
 
     // Setup: generate random cyclotomic polynomials
-    let p1: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
-    let p2: Poly<IRIS_BIT_LENGTH> = rand_poly(IRIS_BIT_LENGTH);
+    let p1: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
+    let p2: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -260,7 +260,7 @@ pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Poly<IRIS_BIT_LENGTH> {
+            benchmark.iter_with_large_drop(|| -> Poly<IrisBits> {
                 poly::flat_karatsuba_mul(p1, p2)
             })
         },
@@ -383,7 +383,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<IRIS_BIT_LENGTH> = Yashe::new(params);
+    let ctx: Yashe<IrisBits> = Yashe::new(params);
 
     let p = ctx.sample_gaussian(&mut rng);
 
@@ -395,7 +395,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
-            benchmark.iter_with_large_drop(|| -> Result<Poly<IRIS_BIT_LENGTH>, &'static str> {
+            benchmark.iter_with_large_drop(|| -> Result<Poly<IrisBits>, &'static str> {
                 p.inverse()
             })
         },
@@ -439,7 +439,7 @@ pub fn bench_keygen_iris(settings: &mut Criterion) {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<IRIS_BIT_LENGTH> = Yashe::new(params);
+    let ctx: Yashe<IrisBits> = Yashe::new(params);
 
     settings.bench_with_input(
         BenchmarkId::new(
@@ -450,7 +450,7 @@ pub fn bench_keygen_iris(settings: &mut Criterion) {
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
             benchmark.iter_with_large_drop(
-                || -> (yashe::PrivateKey<IRIS_BIT_LENGTH>, yashe::PublicKey<IRIS_BIT_LENGTH>) {
+                || -> (yashe::PrivateKey<IrisBits>, yashe::PublicKey<IRIS_BIT_LENGTH>) {
                     ctx.keygen(&mut rand::thread_rng())
                 },
             )

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -6,7 +6,7 @@
 pub use fq::Coeff;
 pub use modular_poly::{
     conf::PolyConf,
-    modulus::{mod_poly, new_unreduced_poly_modulus_slow, FULL_RES_POLY_DEGREE},
+    modulus::{mod_poly, new_unreduced_poly_modulus_slow},
     mul::mul_poly,
     Poly,
 };

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -11,6 +11,10 @@ pub use modular_poly::{
     Poly,
 };
 
+// Only for tests.
+#[cfg(any(test, feature = "benchmark"))]
+pub use modular_poly::conf::TestRes;
+
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(any(test, feature = "benchmark"))]
 pub use modular_poly::modulus::{mod_poly_ark_ref_slow, mod_poly_manual_mut};

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -13,7 +13,7 @@ pub use modular_poly::{
 
 // Only for tests.
 #[cfg(any(test, feature = "benchmark"))]
-pub use modular_poly::conf::TestRes;
+pub use modular_poly::conf::{IrisBits, TestRes};
 
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(any(test, feature = "benchmark"))]

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -5,6 +5,7 @@
 
 pub use fq::Coeff;
 pub use modular_poly::{
+    conf::PolyConf,
     modulus::{mod_poly, new_unreduced_poly_modulus_slow, FULL_RES_POLY_DEGREE},
     mul::mul_poly,
     Poly,

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -21,6 +21,8 @@ use derive_more::{Add, AsRef, Deref, DerefMut, Div, Into, Neg, Rem};
 
 use crate::primitives::poly::{mod_poly, mul_poly, new_unreduced_poly_modulus_slow, Coeff};
 
+pub mod conf;
+
 pub(super) mod inv;
 pub(super) mod modulus;
 pub(super) mod mul;

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -21,7 +21,7 @@ use derive_more::{Add, AsRef, Deref, DerefMut, Div, Into, Neg, Rem};
 
 use crate::primitives::poly::{mod_poly, mul_poly, new_unreduced_poly_modulus_slow, Coeff};
 
-pub mod inv;
+pub(super) mod inv;
 pub(super) mod modulus;
 pub(super) mod mul;
 
@@ -158,6 +158,12 @@ impl<const MAX_POLY_DEGREE: usize> Poly<MAX_POLY_DEGREE> {
     }
 
     // Basic Internal Operations
+
+    /// Returns the primitive inverse of this polynomial in the cyclotomic ring, if it exists.
+    /// Otherwise, returns an error.
+    pub fn inverse(&self) -> Result<Self, String> {
+        inv::inverse(self)
+    }
 
     /// Constructs and returns a new polynomial modulus used for the polynomial field, `X^[MAX_POLY_DEGREE] + 1`.
     /// This is the canonical but un-reduced form of the modulus, because the reduced form is the zero polynomial.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -20,7 +20,7 @@ use ark_ff::{One, Zero};
 use ark_poly::polynomial::univariate::{
     DenseOrSparsePolynomial, DensePolynomial, SparsePolynomial,
 };
-use derive_more::{Add, AsRef, Deref, DerefMut, Div, Into, Neg, Rem};
+use derive_more::{AsRef, Deref, DerefMut, Div, Into, Rem};
 
 use crate::primitives::poly::{
     mod_poly, mul_poly, new_unreduced_poly_modulus_slow, Coeff, PolyConf,
@@ -54,8 +54,9 @@ mod trivial;
     Deref,
     DerefMut,
     Into,
-    Neg,
-    Add,
+    // We can't derive Add or Neg because they add unnecessary bounds on PhantomData
+    //Neg,
+    //Add,
     // We can't derive Sub because the inner type doesn't have the expected impls.
     //Sub,
     // We don't implement DivAssign and RemAssign, because they have hidden clones.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -161,7 +161,7 @@ impl<const MAX_POLY_DEGREE: usize> Poly<MAX_POLY_DEGREE> {
 
     /// Returns the primitive inverse of this polynomial in the cyclotomic ring, if it exists.
     /// Otherwise, returns an error.
-    pub fn inverse(&self) -> Result<Self, String> {
+    pub fn inverse(&self) -> Result<Self, &'static str> {
         inv::inverse(self)
     }
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -79,7 +79,7 @@ impl<C: PolyConf> Poly<C> {
 
     /// Converts the `coeffs` vector into a dense polynomial.
     pub fn from_coefficients_vec(coeffs: Vec<Coeff>) -> Self {
-        let mut poly = Self(DensePolynomial { coeffs }, PhantomData);
+        let mut poly = Self(DensePolynomial { coeffs }, PhantomData, PhantomData);
         poly.truncate_to_canonical_form();
         poly
     }
@@ -96,7 +96,7 @@ impl<C: PolyConf> Poly<C> {
     pub fn naive_mul(&self, other: &Self) -> Self {
         // Deliberately avoid the modular reduction performed by `From`
         // Removing and replacing type wrappers is zero-cost at runtime.
-        Self(DensePolynomial::naive_mul(self, other))
+        Self(DensePolynomial::naive_mul(self, other), PhantomData)
     }
 
     // Re-Implement DenseOrSparsePolynomial methods, so the types are all `Poly`
@@ -224,7 +224,7 @@ impl<C: PolyConf> Poly<C> {
 
 impl<C: PolyConf> From<DensePolynomial<Coeff>> for Poly<C> {
     fn from(poly: DensePolynomial<Coeff>) -> Self {
-        let mut poly = Self(poly);
+        let mut poly = Self(poly, PhantomData);
         poly.reduce_mod_poly();
         poly
     }
@@ -232,7 +232,7 @@ impl<C: PolyConf> From<DensePolynomial<Coeff>> for Poly<C> {
 
 impl<C: PolyConf> From<&DensePolynomial<Coeff>> for Poly<C> {
     fn from(poly: &DensePolynomial<Coeff>) -> Self {
-        let mut poly = Self(poly.clone());
+        let mut poly = Self(poly.clone(), PhantomData);
         poly.reduce_mod_poly();
         poly
     }
@@ -363,7 +363,7 @@ impl<C: PolyConf> Mul<DensePolynomial<Coeff>> for Poly<C> {
 
     /// Multiplies then reduces by the polynomial modulus.
     fn mul(self, rhs: DensePolynomial<Coeff>) -> Self {
-        mul_poly(&self, &Self(rhs))
+        mul_poly(&self, &Self(rhs), PhantomData)
     }
 }
 
@@ -374,6 +374,6 @@ impl<C: PolyConf> Mul<&DensePolynomial<Coeff>> for Poly<C> {
 
     /// Multiplies then reduces by the polynomial modulus.
     fn mul(self, rhs: &DensePolynomial<Coeff>) -> Self {
-        mul_poly(&self, &Self(rhs.clone()))
+        mul_poly(&self, &Self(rhs.clone()), PhantomData)
     }
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -79,7 +79,7 @@ impl<C: PolyConf> Poly<C> {
 
     /// Converts the `coeffs` vector into a dense polynomial.
     pub fn from_coefficients_vec(coeffs: Vec<Coeff>) -> Self {
-        let mut poly = Self(DensePolynomial { coeffs }, PhantomData, PhantomData);
+        let mut poly = Self(DensePolynomial { coeffs }, PhantomData);
         poly.truncate_to_canonical_form();
         poly
     }
@@ -216,9 +216,12 @@ impl<C: PolyConf> Poly<C> {
     /// Returns a new `Poly` filled with `n` zeroes.
     /// This is *not* the canonical form.
     pub(crate) fn non_canonical_zeroes(n: usize) -> Self {
-        Self(DensePolynomial {
-            coeffs: vec![Coeff::zero(); n],
-        })
+        Self(
+            DensePolynomial {
+                coeffs: vec![Coeff::zero(); n],
+            },
+            PhantomData,
+        )
     }
 }
 
@@ -363,7 +366,7 @@ impl<C: PolyConf> Mul<DensePolynomial<Coeff>> for Poly<C> {
 
     /// Multiplies then reduces by the polynomial modulus.
     fn mul(self, rhs: DensePolynomial<Coeff>) -> Self {
-        mul_poly(&self, &Self(rhs), PhantomData)
+        mul_poly(&self, &Self(rhs, PhantomData))
     }
 }
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -22,6 +22,16 @@ pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
     // TODO: add Coeff type
 }
 
+/// Iris bit length polynomial parameters.
+///
+/// This uses the full number of iris bits, which gives an upper bound on benchmarks.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct IrisBits;
+
+impl PolyConf for IrisBits {
+    const MAX_POLY_DEGREE: usize = crate::IRIS_BIT_LENGTH;
+}
+
 /// Full resolution polynomial parameters.
 ///
 /// These are the parameters for full resolution, according to the Inversed Tech report.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -1,0 +1,45 @@
+//! Fixed parameters for modular polynomial types.
+
+/// The polynomial config used in tests.
+//
+// We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
+#[cfg(not(tiny_poly))]
+pub type TestRes = FullRes;
+
+/// The polynomial config used in tests.
+#[cfg(tiny_poly)]
+pub type TestRes = TinyTest;
+
+/// Fixed polynomial parameters.
+///
+/// Polynomials with different parameters are incompatible.
+pub trait PolyConf {
+    /// The maximum exponent in the polynomial.
+    const MAX_POLY_DEGREE: usize;
+
+    // TODO: add Coeff type
+}
+
+/// Full resolution polynomial parameters.
+///
+/// These are the parameters for full resolution, according to the Inversed Tech report.
+#[cfg(not(tiny_poly))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FullRes;
+
+#[cfg(not(tiny_poly))]
+impl PolyConf for FullRes {
+    const MAX_POLY_DEGREE: usize = 2048;
+}
+
+/// Tiny test polynomials, used for finding edge cases in tests.
+///
+/// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
+#[cfg(tiny_poly)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TinyTest;
+
+#[cfg(tiny_poly)]
+impl PolyConf for TinyTest {
+    const MAX_POLY_DEGREE: usize = 8;
+}

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -1,5 +1,7 @@
 //! Fixed parameters for modular polynomial types.
 
+use std::fmt::Debug;
+
 /// The polynomial config used in tests.
 //
 // We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
@@ -13,7 +15,7 @@ pub type TestRes = TinyTest;
 /// Fixed polynomial parameters.
 ///
 /// Polynomials with different parameters are incompatible.
-pub trait PolyConf {
+pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
     /// The maximum exponent in the polynomial.
     const MAX_POLY_DEGREE: usize;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
@@ -3,12 +3,13 @@ use crate::primitives::poly::{Coeff, Poly};
 use ark_ff::{Field, One, Zero};
 use ark_poly::Polynomial;
 
+/// Returns the primitive polynomial which is the inverse of `a` in the
+/// cyclotomic ring, if it exists. Otherwise, returns an error.
+///
 /// Implementation based on Algorithm 3.3.1 (Page 118) from
 /// "A Course in Computational Algebraic Number Theory", Henri Cohen.
 /// We don't divide by content of `a` and `b` every time,
 /// just in the end of the algorithm.
-/// Returns the primitive polynomial which is the inverse of `a` in the
-/// cyclotomic ring, if it exists. Otherwise, returns an error.
 ///
 /// When `d` is a constant polynomial and `a` is the polynomial modulus
 /// (which reduces to `0`), we have that `b/cont(d)` is the primitive

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
@@ -14,9 +14,9 @@ use ark_poly::Polynomial;
 /// When `d` is a constant polynomial and `a` is the polynomial modulus
 /// (which reduces to `0`), we have that `b/cont(d)` is the primitive
 /// multiplicative inverse of `y`.
-pub fn inverse<const MAX_POLY_DEGREE: usize>(
-    a: &Poly<MAX_POLY_DEGREE>,
-) -> Result<Poly<MAX_POLY_DEGREE>, &'static str> {
+pub fn inverse<C: PolyConf>(
+    a: &Poly<C>,
+) -> Result<Poly<C>, &'static str> {
     let unreduced_mod_pol = Poly::new_unreduced_poly_modulus_slow();
 
     let (_x, y, d) = extended_gcd(&unreduced_mod_pol, a);
@@ -29,7 +29,7 @@ pub fn inverse<const MAX_POLY_DEGREE: usize>(
         Err("Non-invertible polynomial")
     } else {
         // Reduce to a primitive polynomial.
-        let mut inv: Poly<MAX_POLY_DEGREE> = y;
+        let mut inv: Poly<C> = y;
         // Compute the inverse of the content
         let content_inv: Coeff = d[0].inverse().expect("just checked for zero");
         // Divide by `content_inv`
@@ -40,11 +40,11 @@ pub fn inverse<const MAX_POLY_DEGREE: usize>(
 }
 
 /// Helps to calculate the equation `cur = prev - q.cur`.
-fn update_diophantine<const MAX_POLY_DEGREE: usize>(
-    mut prev: Poly<MAX_POLY_DEGREE>,
-    cur: Poly<MAX_POLY_DEGREE>,
-    q: &Poly<MAX_POLY_DEGREE>,
-) -> (Poly<MAX_POLY_DEGREE>, Poly<MAX_POLY_DEGREE>) {
+fn update_diophantine<C: PolyConf>(
+    mut prev: Poly<C>,
+    cur: Poly<C>,
+    q: &Poly<C>,
+) -> (Poly<C>, Poly<C>) {
     let mul_res = &cur * q;
     let new_prev = cur;
 
@@ -55,18 +55,18 @@ fn update_diophantine<const MAX_POLY_DEGREE: usize>(
 }
 
 /// Returns polynomials `(x, y, d)` such that `a.x + b.y = d`.
-pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
-    a: &Poly<MAX_POLY_DEGREE>,
-    b: &Poly<MAX_POLY_DEGREE>,
+pub fn extended_gcd<C: PolyConf>(
+    a: &Poly<C>,
+    b: &Poly<C>,
 ) -> (
-    Poly<MAX_POLY_DEGREE>,
-    Poly<MAX_POLY_DEGREE>,
-    Poly<MAX_POLY_DEGREE>,
+    Poly<C>,
+    Poly<C>,
+    Poly<C>,
 ) {
     // Invariant a.xi + b.yi = ri
 
     // init with x0=1, y0=0, r0=a
-    let mut x_prev: Poly<MAX_POLY_DEGREE> = Poly::one();
+    let mut x_prev: Poly<C> = Poly::one();
     let mut y_prev = Poly::zero();
     let mut ri_prev = a.clone();
     // next:     x1=0, y1=1, r1=b
@@ -74,7 +74,7 @@ pub fn extended_gcd<const MAX_POLY_DEGREE: usize>(
     let mut y_cur = Poly::one();
     let mut ri_cur = b.clone();
 
-    let mut q: Poly<MAX_POLY_DEGREE>;
+    let mut q: Poly<C>;
 
     // Sometimes the inputs can be non-canonical.
     ri_cur.truncate_to_canonical_form();

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
@@ -1,7 +1,8 @@
 //! Polynomial inverse.
-use crate::primitives::poly::{Coeff, Poly};
 use ark_ff::{Field, One, Zero};
 use ark_poly::Polynomial;
+
+use crate::primitives::poly::{Coeff, Poly, PolyConf};
 
 /// Returns the primitive polynomial which is the inverse of `a` in the
 /// cyclotomic ring, if it exists. Otherwise, returns an error.
@@ -14,9 +15,7 @@ use ark_poly::Polynomial;
 /// When `d` is a constant polynomial and `a` is the polynomial modulus
 /// (which reduces to `0`), we have that `b/cont(d)` is the primitive
 /// multiplicative inverse of `y`.
-pub fn inverse<C: PolyConf>(
-    a: &Poly<C>,
-) -> Result<Poly<C>, &'static str> {
+pub fn inverse<C: PolyConf>(a: &Poly<C>) -> Result<Poly<C>, &'static str> {
     let unreduced_mod_pol = Poly::new_unreduced_poly_modulus_slow();
 
     let (_x, y, d) = extended_gcd(&unreduced_mod_pol, a);
@@ -55,14 +54,7 @@ fn update_diophantine<C: PolyConf>(
 }
 
 /// Returns polynomials `(x, y, d)` such that `a.x + b.y = d`.
-pub fn extended_gcd<C: PolyConf>(
-    a: &Poly<C>,
-    b: &Poly<C>,
-) -> (
-    Poly<C>,
-    Poly<C>,
-    Poly<C>,
-) {
+pub fn extended_gcd<C: PolyConf>(a: &Poly<C>, b: &Poly<C>) -> (Poly<C>, Poly<C>, Poly<C>) {
     // Invariant a.xi + b.yi = ri
 
     // init with x0=1, y0=0, r0=a

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
@@ -16,7 +16,7 @@ use ark_poly::Polynomial;
 /// multiplicative inverse of `y`.
 pub fn inverse<const MAX_POLY_DEGREE: usize>(
     a: &Poly<MAX_POLY_DEGREE>,
-) -> Result<Poly<MAX_POLY_DEGREE>, String> {
+) -> Result<Poly<MAX_POLY_DEGREE>, &'static str> {
     let unreduced_mod_pol = Poly::new_unreduced_poly_modulus_slow();
 
     let (_x, y, d) = extended_gcd(&unreduced_mod_pol, a);
@@ -24,9 +24,9 @@ pub fn inverse<const MAX_POLY_DEGREE: usize>(
     // If `d` is a non-zero constant, we can compute the inverse of `d`,
     // and calculate the final primitive inverse.
     if d.is_zero() {
-        Err("Can't invert the zero polynomial".to_string())
+        Err("Can't invert the zero polynomial")
     } else if d.degree() > 0 {
-        Err("Non-invertible polynomial".to_string())
+        Err("Non-invertible polynomial")
     } else {
         // Reduce to a primitive polynomial.
         let mut inv: Poly<MAX_POLY_DEGREE> = y;

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -8,7 +8,7 @@ use crate::primitives::poly::{Coeff, Poly};
 // TODO: delete this after the search and replace.
 use super::conf::PolyConf;
 /// Temporary alias to make things compile.
-pub const FULL_RES_POLY_DEGREE: usize = super::conf::TestRes::C::MAX_POLY_DEGREE;
+pub const FULL_RES_POLY_DEGREE: usize = super::conf::TestRes::MAX_POLY_DEGREE;
 
 /// The fastest available modular polynomial operation.
 pub use mod_poly_manual_mut as mod_poly;
@@ -46,9 +46,7 @@ pub fn mod_poly_manual_mut<C: PolyConf>(dividend: &mut Poly<C>) {
 ///
 /// This clones then uses the manual implementation.
 #[cfg(inefficient)]
-pub fn mod_poly_manual_ref<C: PolyConf>(
-    dividend: &Poly<C>,
-) -> Poly<C> {
+pub fn mod_poly_manual_ref<C: PolyConf>(dividend: &Poly<C>) -> Poly<C> {
     let mut dividend = dividend.clone();
     mod_poly_manual_mut(&mut dividend);
     dividend
@@ -57,9 +55,7 @@ pub fn mod_poly_manual_ref<C: PolyConf>(
 /// Returns the remainder of `dividend % [POLY_MODULUS]`, as a polynomial.
 ///
 /// This uses an [`ark-poly`] library implementation, which always creates a new polynomial.
-pub fn mod_poly_ark_ref_slow<C: PolyConf>(
-    dividend: &Poly<C>,
-) -> Poly<C> {
+pub fn mod_poly_ark_ref_slow<C: PolyConf>(dividend: &Poly<C>) -> Poly<C> {
     // The DenseOrSparsePolynomial implementation ensures canonical form.
     let (_quotient, remainder) = dividend
         .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<C>())

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -1,23 +1,14 @@
 //! Reduction by the polynomial modulus `X^[MAX_POLY_DEGREE] + 1`.
 
 use ark_ff::{One, Zero};
-
-use crate::primitives::poly::{Coeff, Poly};
 use ark_poly::polynomial::Polynomial;
 
-/// The maximum exponent in the polynomial.
-///
-/// These are the parameters for full resolution, according to the Inversed Tech report.
-/// N = 2048
-#[cfg(not(tiny_poly))]
-pub const FULL_RES_POLY_DEGREE: usize = 2048;
+use crate::primitives::poly::{Coeff, Poly};
 
-/// The maximum exponent in the test-only polynomial.
-///
-/// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
-/// N = 8
-#[cfg(tiny_poly)]
-pub const FULL_RES_POLY_DEGREE: usize = 8;
+// TODO: delete this after the search and replace.
+use super::conf::PolyConf;
+/// Temporary alias to make things compile.
+pub const FULL_RES_POLY_DEGREE: usize = super::conf::TestRes::MAX_POLY_DEGREE;
 
 /// The fastest available modular polynomial operation.
 pub use mod_poly_manual_mut as mod_poly;

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -1,4 +1,4 @@
-//! Reduction by the polynomial modulus `X^[MAX_POLY_DEGREE] + 1`.
+//! Reduction by the polynomial modulus `X^[C::MAX_POLY_DEGREE] + 1`.
 
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::Polynomial;
@@ -8,7 +8,7 @@ use crate::primitives::poly::{Coeff, Poly};
 // TODO: delete this after the search and replace.
 use super::conf::PolyConf;
 /// Temporary alias to make things compile.
-pub const FULL_RES_POLY_DEGREE: usize = super::conf::TestRes::MAX_POLY_DEGREE;
+pub const FULL_RES_POLY_DEGREE: usize = super::conf::TestRes::C::MAX_POLY_DEGREE;
 
 /// The fastest available modular polynomial operation.
 pub use mod_poly_manual_mut as mod_poly;
@@ -16,11 +16,11 @@ pub use mod_poly_manual_mut as mod_poly;
 /// Reduces `dividend` to `dividend % [POLY_MODULUS]`.
 ///
 /// This is the most efficient manual implementation.
-pub fn mod_poly_manual_mut<const MAX_POLY_DEGREE: usize>(dividend: &mut Poly<MAX_POLY_DEGREE>) {
-    let mut i = MAX_POLY_DEGREE;
+pub fn mod_poly_manual_mut<C: PolyConf>(dividend: &mut Poly<C>) {
+    let mut i = C::MAX_POLY_DEGREE;
     while i < dividend.coeffs.len() {
-        let q = i / MAX_POLY_DEGREE;
-        let r = i % MAX_POLY_DEGREE;
+        let q = i / C::MAX_POLY_DEGREE;
+        let r = i % C::MAX_POLY_DEGREE;
 
         // In the cyclotomic ring we have that XˆN = -1,
         // therefore all elements from N to 2N-1 are negated.
@@ -35,8 +35,8 @@ pub fn mod_poly_manual_mut<const MAX_POLY_DEGREE: usize>(dividend: &mut Poly<MAX
         i += 1;
     }
 
-    // The coefficients of MAX_POLY_DEGREE and higher have already been summed above.
-    dividend.coeffs.truncate(MAX_POLY_DEGREE);
+    // The coefficients of C::MAX_POLY_DEGREE and higher have already been summed above.
+    dividend.coeffs.truncate(C::MAX_POLY_DEGREE);
 
     // The coefficients could sum to zero, so make sure the polynomial is in the canonical form.
     dividend.truncate_to_canonical_form();
@@ -46,9 +46,9 @@ pub fn mod_poly_manual_mut<const MAX_POLY_DEGREE: usize>(dividend: &mut Poly<MAX
 ///
 /// This clones then uses the manual implementation.
 #[cfg(inefficient)]
-pub fn mod_poly_manual_ref<const MAX_POLY_DEGREE: usize>(
-    dividend: &Poly<MAX_POLY_DEGREE>,
-) -> Poly<MAX_POLY_DEGREE> {
+pub fn mod_poly_manual_ref<C: PolyConf>(
+    dividend: &Poly<C>,
+) -> Poly<C> {
     let mut dividend = dividend.clone();
     mod_poly_manual_mut(&mut dividend);
     dividend
@@ -57,12 +57,12 @@ pub fn mod_poly_manual_ref<const MAX_POLY_DEGREE: usize>(
 /// Returns the remainder of `dividend % [POLY_MODULUS]`, as a polynomial.
 ///
 /// This uses an [`ark-poly`] library implementation, which always creates a new polynomial.
-pub fn mod_poly_ark_ref_slow<const MAX_POLY_DEGREE: usize>(
-    dividend: &Poly<MAX_POLY_DEGREE>,
-) -> Poly<MAX_POLY_DEGREE> {
+pub fn mod_poly_ark_ref_slow<C: PolyConf>(
+    dividend: &Poly<C>,
+) -> Poly<C> {
     // The DenseOrSparsePolynomial implementation ensures canonical form.
     let (_quotient, remainder) = dividend
-        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<MAX_POLY_DEGREE>())
+        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<C>())
         .expect("POLY_MODULUS is not zero");
 
     remainder
@@ -72,28 +72,28 @@ pub fn mod_poly_ark_ref_slow<const MAX_POLY_DEGREE: usize>(
 ///
 /// This uses an [`ark-poly`] library implementation, and entirely replaces the inner polynomial representation.
 #[cfg(inefficient)]
-pub fn mod_poly_ark_mut<const MAX_POLY_DEGREE: usize>(dividend: &mut Poly<MAX_POLY_DEGREE>) {
+pub fn mod_poly_ark_mut<C: PolyConf>(dividend: &mut Poly<C>) {
     let remainder = mod_poly_ark_ref(dividend);
     *dividend = remainder;
 }
 
-/// Constructs and returns a new polynomial modulus used for the polynomial field, `X^[MAX_POLY_DEGREE] + 1`.
-/// This means that `X^[MAX_POLY_DEGREE] = -1`.
+/// Constructs and returns a new polynomial modulus used for the polynomial field, `X^[C::MAX_POLY_DEGREE] + 1`.
+/// This means that `X^[C::MAX_POLY_DEGREE] = -1`.
 ///
 /// This is the canonical but un-reduced form of the modulus, because the reduced form is the zero polynomial.
 ///
 /// TODO: work out how to generically make this a lazy static.
 /// Crates like `interned` or `lazy_static` might help, but we'll have to expand their macros and make them generic.
-pub fn new_unreduced_poly_modulus_slow<const MAX_POLY_DEGREE: usize>() -> Poly<MAX_POLY_DEGREE> {
+pub fn new_unreduced_poly_modulus_slow<C: PolyConf>() -> Poly<C> {
     let mut poly = Poly::zero();
 
     // Since the leading coefficient is non-zero, this is in canonical form.
     // Resize to the maximum size first, to avoid repeated reallocations.
-    poly[MAX_POLY_DEGREE] = Coeff::one();
+    poly[C::MAX_POLY_DEGREE] = Coeff::one();
     poly[0] = Coeff::one();
 
     // Check canonicity and degree.
-    assert_eq!(poly.degree(), MAX_POLY_DEGREE);
+    assert_eq!(poly.degree(), C::MAX_POLY_DEGREE);
 
     poly
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -3,12 +3,7 @@
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::Polynomial;
 
-use crate::primitives::poly::{Coeff, Poly};
-
-// TODO: delete this after the search and replace.
-use super::conf::PolyConf;
-/// Temporary alias to make things compile.
-pub const FULL_RES_POLY_DEGREE: usize = super::conf::TestRes::MAX_POLY_DEGREE;
+use crate::primitives::poly::{Coeff, Poly, PolyConf};
 
 /// The fastest available modular polynomial operation.
 pub use mod_poly_manual_mut as mod_poly;

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
@@ -9,7 +9,7 @@ use static_assertions::const_assert_eq;
 use crate::primitives::poly::{
     mod_poly,
     modular_poly::modulus::{mod_poly_ark_ref_slow, mod_poly_manual_mut},
-    Coeff, Poly,
+    Coeff, Poly, PolyConf,
 };
 
 // Simple multiplication by a field element.
@@ -57,10 +57,7 @@ pub const FLAT_KARATSUBA_INITIAL_LAYER: u32 = 2;
 
 /// Returns `a * b` followed by reduction mod `XˆN + 1`.
 /// All polynomials have maximum degree `C::MAX_POLY_DEGREE`.
-pub fn naive_cyclotomic_mul<C: PolyConf>(
-    a: &Poly<C>,
-    b: &Poly<C>,
-) -> Poly<C> {
+pub fn naive_cyclotomic_mul<C: PolyConf>(a: &Poly<C>, b: &Poly<C>) -> Poly<C> {
     debug_assert!(a.degree() <= C::MAX_POLY_DEGREE);
     debug_assert!(b.degree() <= C::MAX_POLY_DEGREE);
 
@@ -108,10 +105,7 @@ pub fn naive_cyclotomic_mul<C: PolyConf>(
 /// debug-assertions = true
 /// overflow-checks = true
 /// ```
-pub fn rec_karatsuba_mul<C: PolyConf>(
-    a: &Poly<C>,
-    b: &Poly<C>,
-) -> Poly<C> {
+pub fn rec_karatsuba_mul<C: PolyConf>(a: &Poly<C>, b: &Poly<C>) -> Poly<C> {
     rec_karatsuba_mul_inner(a, b, C::MAX_POLY_DEGREE)
 }
 
@@ -119,11 +113,7 @@ pub fn rec_karatsuba_mul<C: PolyConf>(
 /// The returned polynomial has a degree less than or equal to `chunk`.
 ///
 /// At each recusrsion level, polynomials start with maximum degree `chunk`, and are split to maximum degree `chunk/2`.
-fn rec_karatsuba_mul_inner<C: PolyConf>(
-    a: &Poly<C>,
-    b: &Poly<C>,
-    chunk: usize,
-) -> Poly<C> {
+fn rec_karatsuba_mul_inner<C: PolyConf>(a: &Poly<C>, b: &Poly<C>, chunk: usize) -> Poly<C> {
     debug_assert!(a.degree() <= chunk);
     debug_assert!(b.degree() <= chunk);
 
@@ -203,10 +193,7 @@ fn rec_karatsuba_mul_inner<C: PolyConf>(
 // - split large code blocks into smaller functions, and benchmark the overall performance.
 #[cfg(any(test, feature = "benchmark"))]
 #[allow(clippy::cognitive_complexity)]
-pub fn flat_karatsuba_mul<C: PolyConf>(
-    a: &Poly<C>,
-    b: &Poly<C>,
-) -> Poly<C> {
+pub fn flat_karatsuba_mul<C: PolyConf>(a: &Poly<C>, b: &Poly<C>) -> Poly<C> {
     use std::ops::{Add, Sub};
 
     debug_assert!(a.degree() <= C::MAX_POLY_DEGREE);
@@ -234,7 +221,8 @@ pub fn flat_karatsuba_mul<C: PolyConf>(
     debug_assert_eq!(
         a_chunks.len(),
         C::MAX_POLY_DEGREE / chunk_size,
-        "{C::MAX_POLY_DEGREE} / {chunk_size}"
+        "{} / {chunk_size}",
+        C::MAX_POLY_DEGREE
     );
 
     // Take 2 at each step
@@ -280,7 +268,8 @@ pub fn flat_karatsuba_mul<C: PolyConf>(
         debug_assert_eq!(
             a_chunks.len(),
             C::MAX_POLY_DEGREE / chunk_size,
-            "{C::MAX_POLY_DEGREE} / {chunk_size}"
+            "{} / {chunk_size}",
+            C::MAX_POLY_DEGREE
         );
 
         // Take two polynomials each round
@@ -330,10 +319,7 @@ pub fn flat_karatsuba_mul<C: PolyConf>(
 /// Split the polynomial into `C::MAX_POLY_DEGREE / k` parts, in order from the constant term to the degree.
 /// Any of the polynomials can be zero.
 #[cfg(any(test, feature = "benchmark"))]
-pub fn poly_split<C: PolyConf>(
-    a: &Poly<C>,
-    k: usize,
-) -> Vec<Poly<C>> {
+pub fn poly_split<C: PolyConf>(a: &Poly<C>, k: usize) -> Vec<Poly<C>> {
     // invariant: k must be a power of 2
     debug_assert_eq!(k.count_ones(), 1);
 
@@ -356,10 +342,7 @@ pub fn poly_split<C: PolyConf>(
 ///
 /// All polynomials have maximum degree `C::MAX_POLY_DEGREE`. The modulus remains the same even after
 /// the split.
-pub fn poly_split_half<C: PolyConf>(
-    a: &Poly<C>,
-    chunk: usize,
-) -> (Poly<C>, Poly<C>) {
+pub fn poly_split_half<C: PolyConf>(a: &Poly<C>, chunk: usize) -> (Poly<C>, Poly<C>) {
     debug_assert!(chunk <= C::MAX_POLY_DEGREE);
 
     let (quotient, remainder) = a.new_div_xn(chunk / 2);

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -5,6 +5,7 @@
 
 use std::{
     borrow::Borrow,
+    marker::PhantomData,
     ops::{Add, AddAssign, Mul, Sub, SubAssign},
 };
 
@@ -67,7 +68,7 @@ impl<C: PolyConf> Add<&Poly<C>> for Poly<C> {
     type Output = Self;
 
     fn add(self, rhs: &Self) -> Self {
-        Poly(&self.0 + &rhs.0)
+        Poly(&self.0 + &rhs.0, PhantomData)
     }
 }
 
@@ -75,7 +76,7 @@ impl<C: PolyConf> Add<Poly<C>> for &Poly<C> {
     type Output = Poly<C>;
 
     fn add(self, rhs: Poly<C>) -> Self::Output {
-        Poly(&self.0 + &rhs.0)
+        Poly(&self.0 + &rhs.0, PhantomData)
     }
 }
 
@@ -83,7 +84,7 @@ impl<'a, 'b, C: PolyConf> Add<&'a Poly<C>> for &'b Poly<C> {
     type Output = Poly<C>;
 
     fn add(self, rhs: &'a Poly<C>) -> Self::Output {
-        Poly(&self.0 + &rhs.0)
+        Poly(&self.0 + &rhs.0, PhantomData)
     }
 }
 
@@ -99,7 +100,7 @@ impl<C: PolyConf> Sub<&Poly<C>> for Poly<C> {
     type Output = Self;
 
     fn sub(self, rhs: &Self) -> Self {
-        Poly(&self.0 - &rhs.0)
+        Poly(&self.0 - &rhs.0, PhantomData)
     }
 }
 
@@ -107,7 +108,7 @@ impl<C: PolyConf> Sub<Poly<C>> for &Poly<C> {
     type Output = Poly<C>;
 
     fn sub(self, rhs: Poly<C>) -> Self::Output {
-        Poly(&self.0 - &rhs.0)
+        Poly(&self.0 - &rhs.0, PhantomData)
     }
 }
 
@@ -115,7 +116,7 @@ impl<'a, 'b, C: PolyConf> Sub<&'a Poly<C>> for &'b Poly<C> {
     type Output = Poly<C>;
 
     fn sub(self, rhs: &'a Poly<C>) -> Self::Output {
-        Poly(&self.0 - &rhs.0)
+        Poly(&self.0 - &rhs.0, PhantomData)
     }
 }
 
@@ -148,7 +149,7 @@ impl<C: PolyConf> Mul<Coeff> for Poly<C> {
     type Output = Self;
 
     fn mul(self, rhs: Coeff) -> Self {
-        Poly(&self.0 * rhs)
+        Poly(&self.0 * rhs, PhantomData)
     }
 }
 
@@ -156,6 +157,6 @@ impl<C: PolyConf> Mul<Coeff> for &Poly<C> {
     type Output = Poly<C>;
 
     fn mul(self, rhs: Coeff) -> Self::Output {
-        Poly(&self.0 * rhs)
+        Poly(&self.0 * rhs, PhantomData)
     }
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -33,7 +33,7 @@ impl<'a, C: PolyConf> From<&'a Poly<C>> for DenseOrSparsePolynomial<'a, Coeff> {
 
 impl<C: PolyConf> Zero for Poly<C> {
     fn zero() -> Self {
-        Self(DensePolynomial { coeffs: vec![] })
+        Self(DensePolynomial { coeffs: vec![] }, PhantomData)
     }
 
     fn is_zero(&self) -> bool {
@@ -91,7 +91,7 @@ impl<C: PolyConf> Sub for Poly<C> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        Self(&self.0 - &rhs.0)
+        Self(&self.0 - &rhs.0, PhantomData)
     }
 }
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -13,29 +13,29 @@ use ark_poly::polynomial::univariate::{DenseOrSparsePolynomial, DensePolynomial}
 
 use crate::primitives::poly::modular_poly::{Coeff, Poly};
 
-impl<const MAX_POLY_DEGREE: usize> Borrow<DensePolynomial<Coeff>> for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Borrow<DensePolynomial<Coeff>> for Poly<C> {
     fn borrow(&self) -> &DensePolynomial<Coeff> {
         &self.0
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> From<Poly<MAX_POLY_DEGREE>>
+impl<C: PolyConf> From<Poly<C>>
     for DenseOrSparsePolynomial<'static, Coeff>
 {
-    fn from(poly: Poly<MAX_POLY_DEGREE>) -> DenseOrSparsePolynomial<'static, Coeff> {
+    fn from(poly: Poly<C>) -> DenseOrSparsePolynomial<'static, Coeff> {
         poly.0.into()
     }
 }
 
-impl<'a, const MAX_POLY_DEGREE: usize> From<&'a Poly<MAX_POLY_DEGREE>>
+impl<'a, C: PolyConf> From<&'a Poly<C>>
     for DenseOrSparsePolynomial<'a, Coeff>
 {
-    fn from(poly: &'a Poly<MAX_POLY_DEGREE>) -> DenseOrSparsePolynomial<'a, Coeff> {
+    fn from(poly: &'a Poly<C>) -> DenseOrSparsePolynomial<'a, Coeff> {
         (&poly.0).into()
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> Zero for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Zero for Poly<C> {
     fn zero() -> Self {
         Self(DensePolynomial { coeffs: vec![] })
     }
@@ -45,7 +45,7 @@ impl<const MAX_POLY_DEGREE: usize> Zero for Poly<MAX_POLY_DEGREE> {
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> One for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> One for Poly<C> {
     fn one() -> Self {
         let mut poly = Self::zero();
         poly[0] = Coeff::one();
@@ -67,7 +67,7 @@ impl<const MAX_POLY_DEGREE: usize> One for Poly<MAX_POLY_DEGREE> {
 // Some missing truncate_leading_zeroes() can cause a panic in degree():
 // <https://github.com/Inversed-Tech/eyelid/issues/43>
 
-impl<const MAX_POLY_DEGREE: usize> Add<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Add<&Poly<C>> for Poly<C> {
     type Output = Self;
 
     fn add(self, rhs: &Self) -> Self {
@@ -75,25 +75,25 @@ impl<const MAX_POLY_DEGREE: usize> Add<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> Add<Poly<MAX_POLY_DEGREE>> for &Poly<MAX_POLY_DEGREE> {
-    type Output = Poly<MAX_POLY_DEGREE>;
+impl<C: PolyConf> Add<Poly<C>> for &Poly<C> {
+    type Output = Poly<C>;
 
-    fn add(self, rhs: Poly<MAX_POLY_DEGREE>) -> Self::Output {
+    fn add(self, rhs: Poly<C>) -> Self::Output {
         Poly(&self.0 + &rhs.0)
     }
 }
 
-impl<'a, 'b, const MAX_POLY_DEGREE: usize> Add<&'a Poly<MAX_POLY_DEGREE>>
-    for &'b Poly<MAX_POLY_DEGREE>
+impl<'a, 'b, C: PolyConf> Add<&'a Poly<C>>
+    for &'b Poly<C>
 {
-    type Output = Poly<MAX_POLY_DEGREE>;
+    type Output = Poly<C>;
 
-    fn add(self, rhs: &'a Poly<MAX_POLY_DEGREE>) -> Self::Output {
+    fn add(self, rhs: &'a Poly<C>) -> Self::Output {
         Poly(&self.0 + &rhs.0)
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> Sub for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Sub for Poly<C> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -101,7 +101,7 @@ impl<const MAX_POLY_DEGREE: usize> Sub for Poly<MAX_POLY_DEGREE> {
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> Sub<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Sub<&Poly<C>> for Poly<C> {
     type Output = Self;
 
     fn sub(self, rhs: &Self) -> Self {
@@ -109,50 +109,50 @@ impl<const MAX_POLY_DEGREE: usize> Sub<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> Sub<Poly<MAX_POLY_DEGREE>> for &Poly<MAX_POLY_DEGREE> {
-    type Output = Poly<MAX_POLY_DEGREE>;
+impl<C: PolyConf> Sub<Poly<C>> for &Poly<C> {
+    type Output = Poly<C>;
 
-    fn sub(self, rhs: Poly<MAX_POLY_DEGREE>) -> Self::Output {
+    fn sub(self, rhs: Poly<C>) -> Self::Output {
         Poly(&self.0 - &rhs.0)
     }
 }
 
-impl<'a, 'b, const MAX_POLY_DEGREE: usize> Sub<&'a Poly<MAX_POLY_DEGREE>>
-    for &'b Poly<MAX_POLY_DEGREE>
+impl<'a, 'b, C: PolyConf> Sub<&'a Poly<C>>
+    for &'b Poly<C>
 {
-    type Output = Poly<MAX_POLY_DEGREE>;
+    type Output = Poly<C>;
 
-    fn sub(self, rhs: &'a Poly<MAX_POLY_DEGREE>) -> Self::Output {
+    fn sub(self, rhs: &'a Poly<C>) -> Self::Output {
         Poly(&self.0 - &rhs.0)
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> AddAssign for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> AddAssign for Poly<C> {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += &rhs.0;
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> AddAssign<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> AddAssign<&Poly<C>> for Poly<C> {
     fn add_assign(&mut self, rhs: &Self) {
         self.0 += &rhs.0;
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> SubAssign for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> SubAssign for Poly<C> {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= &rhs.0;
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> SubAssign<&Poly<MAX_POLY_DEGREE>> for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> SubAssign<&Poly<C>> for Poly<C> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.0 -= &rhs.0;
     }
 }
 
 // Multiplying by a scalar can't increase the degree, so it is trivial.
-impl<const MAX_POLY_DEGREE: usize> Mul<Coeff> for Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Mul<Coeff> for Poly<C> {
     type Output = Self;
 
     fn mul(self, rhs: Coeff) -> Self {
@@ -160,8 +160,8 @@ impl<const MAX_POLY_DEGREE: usize> Mul<Coeff> for Poly<MAX_POLY_DEGREE> {
     }
 }
 
-impl<const MAX_POLY_DEGREE: usize> Mul<Coeff> for &Poly<MAX_POLY_DEGREE> {
-    type Output = Poly<MAX_POLY_DEGREE>;
+impl<C: PolyConf> Mul<Coeff> for &Poly<C> {
+    type Output = Poly<C>;
 
     fn mul(self, rhs: Coeff) -> Self::Output {
         Poly(&self.0 * rhs)

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -11,7 +11,7 @@ use std::{
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::univariate::{DenseOrSparsePolynomial, DensePolynomial};
 
-use crate::primitives::poly::modular_poly::{Coeff, Poly};
+use crate::primitives::poly::{modular_poly::Poly, Coeff, PolyConf};
 
 impl<C: PolyConf> Borrow<DensePolynomial<Coeff>> for Poly<C> {
     fn borrow(&self) -> &DensePolynomial<Coeff> {
@@ -19,17 +19,13 @@ impl<C: PolyConf> Borrow<DensePolynomial<Coeff>> for Poly<C> {
     }
 }
 
-impl<C: PolyConf> From<Poly<C>>
-    for DenseOrSparsePolynomial<'static, Coeff>
-{
+impl<C: PolyConf> From<Poly<C>> for DenseOrSparsePolynomial<'static, Coeff> {
     fn from(poly: Poly<C>) -> DenseOrSparsePolynomial<'static, Coeff> {
         poly.0.into()
     }
 }
 
-impl<'a, C: PolyConf> From<&'a Poly<C>>
-    for DenseOrSparsePolynomial<'a, Coeff>
-{
+impl<'a, C: PolyConf> From<&'a Poly<C>> for DenseOrSparsePolynomial<'a, Coeff> {
     fn from(poly: &'a Poly<C>) -> DenseOrSparsePolynomial<'a, Coeff> {
         (&poly.0).into()
     }
@@ -83,9 +79,7 @@ impl<C: PolyConf> Add<Poly<C>> for &Poly<C> {
     }
 }
 
-impl<'a, 'b, C: PolyConf> Add<&'a Poly<C>>
-    for &'b Poly<C>
-{
+impl<'a, 'b, C: PolyConf> Add<&'a Poly<C>> for &'b Poly<C> {
     type Output = Poly<C>;
 
     fn add(self, rhs: &'a Poly<C>) -> Self::Output {
@@ -117,9 +111,7 @@ impl<C: PolyConf> Sub<Poly<C>> for &Poly<C> {
     }
 }
 
-impl<'a, 'b, C: PolyConf> Sub<&'a Poly<C>>
-    for &'b Poly<C>
-{
+impl<'a, 'b, C: PolyConf> Sub<&'a Poly<C>> for &'b Poly<C> {
     type Output = Poly<C>;
 
     fn sub(self, rhs: &'a Poly<C>) -> Self::Output {

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -6,7 +6,7 @@
 use std::{
     borrow::Borrow,
     marker::PhantomData,
-    ops::{Add, AddAssign, Mul, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
 };
 
 use ark_ff::{One, Zero};
@@ -58,11 +58,27 @@ impl<C: PolyConf> One for Poly<C> {
     }
 }
 
-// Poly + Poly and similar are provided by the derive
+// Poly / Poly and Poly % Poly are provided by the derives
 
 // TODO:
 // Some missing truncate_leading_zeroes() can cause a panic in degree():
 // <https://github.com/Inversed-Tech/eyelid/issues/43>
+
+impl<C: PolyConf> Neg for Poly<C> {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Poly(-self.0, PhantomData)
+    }
+}
+
+impl<C: PolyConf> Add<Poly<C>> for Poly<C> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Poly(&self.0 + &rhs.0, PhantomData)
+    }
+}
 
 impl<C: PolyConf> Add<&Poly<C>> for Poly<C> {
     type Output = Self;

--- a/eyelid-match-ops/src/primitives/poly/test/gen.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/gen.rs
@@ -3,7 +3,7 @@
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
 use rand::Rng;
 
-use crate::primitives::poly::Poly;
+use crate::primitives::poly::{Poly, PolyConf};
 
 // Doc links only
 #[allow(unused_imports)]

--- a/eyelid-match-ops/src/primitives/poly/test/gen.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/gen.rs
@@ -10,11 +10,11 @@ use crate::primitives::poly::Poly;
 use crate::primitives::poly::Coeff;
 
 /// Returns an un-reduced cyclotomic polynomial of `degree`, with random coefficients in [`Coeff`].
-/// `degree` must be less than or equal to `MAX_POLY_DEGREE`.
+/// `degree` must be less than or equal to `C::MAX_POLY_DEGREE`.
 ///
 /// In rare cases, the degree can be less than `degree`,
-/// because the random coefficient of `X^[MAX_POLY_DEGREE]` is zero.
-pub fn rand_poly<const MAX_POLY_DEGREE: usize>(degree: usize) -> Poly<MAX_POLY_DEGREE> {
+/// because the random coefficient of `X^[C::MAX_POLY_DEGREE]` is zero.
+pub fn rand_poly<C: PolyConf>(degree: usize) -> Poly<C> {
     use rand::thread_rng;
 
     // We can't use test_rng() here, because a deterministic RNG can make benchmarks inaccurate.
@@ -28,7 +28,7 @@ pub fn rand_poly<const MAX_POLY_DEGREE: usize>(degree: usize) -> Poly<MAX_POLY_D
     poly
 }
 
-impl<const MAX_POLY_DEGREE: usize> Poly<MAX_POLY_DEGREE> {
+impl<C: PolyConf> Poly<C> {
     // Shadow DenseUVPolynomial methods, but only make the method available in test code.
 
     /// Returns a random polynomial with degree `d`.

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -6,7 +6,7 @@ use crate::primitives::{
     poly::{
         modular_poly::inv::{extended_gcd, inverse},
         test::gen::rand_poly,
-        Poly,
+        Poly, PolyConf,
     },
     yashe::{Yashe, YasheParams},
 };

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -66,7 +66,7 @@ fn test_key_generation_and_inverse() {
 
 #[test]
 fn test_inverse_with_random_coefficients() {
-    let f: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
+    let f: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
     inverse_test_helper(&f);
 }
 

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -12,8 +12,6 @@ use crate::primitives::{
 };
 
 #[cfg(test)]
-use crate::primitives::poly::FULL_RES_POLY_DEGREE;
-#[cfg(test)]
 use ark_poly::Polynomial;
 
 fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -6,7 +6,7 @@ use crate::primitives::{
     poly::{
         modular_poly::inv::{extended_gcd, inverse},
         test::gen::rand_poly,
-        Poly, PolyConf,
+        Poly, PolyConf, TestRes,
     },
     yashe::{Yashe, YasheParams},
 };

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -16,7 +16,7 @@ use crate::primitives::poly::FULL_RES_POLY_DEGREE;
 #[cfg(test)]
 use ark_poly::Polynomial;
 
-fn inverse_test_helper<const MAX_POLY_DEGREE: usize>(f: &Poly<MAX_POLY_DEGREE>) {
+fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {
     // REMARK: For our parameter choices it is very likely to find
     // the inverse in the first attempt.
     let out = inverse(f);

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -56,7 +56,7 @@ fn test_key_generation_and_inverse() {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<FULL_RES_POLY_DEGREE> = Yashe::new(params);
+    let ctx: Yashe<TestRes> = Yashe::new(params);
     let f = ctx.sample_gaussian(&mut rng);
 
     // REMARK: For our parameter choices it is very likely to find
@@ -66,25 +66,25 @@ fn test_key_generation_and_inverse() {
 
 #[test]
 fn test_inverse_with_random_coefficients() {
-    let f: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE);
+    let f: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE);
     inverse_test_helper(&f);
 }
 
 #[test]
 fn test_edge_cases() {
     // Inverse of one is one
-    let one_poly: Poly<FULL_RES_POLY_DEGREE> = Poly::one();
+    let one_poly: Poly<TestRes> = Poly::one();
     let mut out = inverse(&one_poly.clone());
     assert_eq!(out, Ok(one_poly.clone()));
 
     // Inverse of minus one is minus one
-    let zero_poly: Poly<FULL_RES_POLY_DEGREE> = Poly::zero();
+    let zero_poly: Poly<TestRes> = Poly::zero();
     let minus_one_poly = zero_poly - one_poly.clone();
     out = inverse(&minus_one_poly.clone());
     assert_eq!(out, Ok(minus_one_poly));
 
     // Inverse of zero is error
-    let zero_poly: Poly<FULL_RES_POLY_DEGREE> = Poly::zero();
+    let zero_poly: Poly<TestRes> = Poly::zero();
     out = inverse(&zero_poly.clone());
     assert!(out.is_err());
 }

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -5,7 +5,7 @@ use ark_poly::Polynomial;
 
 use crate::primitives::poly::{
     flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
-    test::gen::rand_poly, Coeff, Poly, PolyConf, TestRes, FULL_RES_POLY_DEGREE,
+    test::gen::rand_poly, Coeff, Poly, PolyConf, TestRes,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
@@ -104,7 +104,7 @@ where
         let p1 = Poly::xn(i);
         let p2 = Poly::xn(C::MAX_POLY_DEGREE - i);
 
-        if i == 0 || i == FULL_RES_POLY_DEGREE {
+        if i == 0 || i == TestRes::MAX_POLY_DEGREE {
             assert_eq!(p1.degree(), 0);
             assert_eq!(p2.degree(), 0);
         } else {
@@ -126,18 +126,18 @@ fn test_karatsuba_mul_rand_consistent() {
 
     #[allow(clippy::int_plus_one)]
     {
-        assert!(p1.degree() <= FULL_RES_POLY_DEGREE - 1);
-        assert!(p2.degree() <= FULL_RES_POLY_DEGREE - 1);
+        assert!(p1.degree() <= TestRes::MAX_POLY_DEGREE - 1);
+        assert!(p2.degree() <= TestRes::MAX_POLY_DEGREE - 1);
     }
 
     let expected = naive_cyclotomic_mul(&p1, &p2);
-    assert!(expected.degree() <= FULL_RES_POLY_DEGREE);
+    assert!(expected.degree() <= TestRes::MAX_POLY_DEGREE);
 
     let rec_res = rec_karatsuba_mul(&p1, &p2);
-    assert!(rec_res.degree() <= FULL_RES_POLY_DEGREE);
+    assert!(rec_res.degree() <= TestRes::MAX_POLY_DEGREE);
 
     let flat_res = flat_karatsuba_mul(&p1, &p2);
-    assert!(flat_res.degree() <= FULL_RES_POLY_DEGREE);
+    assert!(flat_res.degree() <= TestRes::MAX_POLY_DEGREE);
 
     assert_eq!(expected, rec_res);
     assert_eq!(expected, flat_res);

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -8,7 +8,7 @@ use crate::primitives::poly::{
     test::gen::rand_poly, Coeff, Poly, FULL_RES_POLY_DEGREE,
 };
 
-/// Test cyclotomic multiplication of a random polynomial by `X^{[MAX_POLY_DEGREE] - 1}`.
+/// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
 #[test]
 fn test_cyclotomic_mul_rand_xnm1() {
     check_cyclotomic_mul_rand_xnm1::<FULL_RES_POLY_DEGREE, _>(naive_cyclotomic_mul);
@@ -16,39 +16,39 @@ fn test_cyclotomic_mul_rand_xnm1() {
     check_cyclotomic_mul_rand_xnm1::<FULL_RES_POLY_DEGREE, _>(flat_karatsuba_mul);
 }
 
-/// Check `mul_fn` correctly implements cyclotomic multiplication of a random polynomial by `X^{[MAX_POLY_DEGREE] - 1}`.
-fn check_cyclotomic_mul_rand_xnm1<const MAX_POLY_DEGREE: usize, F>(mul_fn: F)
+/// Check `mul_fn` correctly implements cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
+fn check_cyclotomic_mul_rand_xnm1<C: PolyConf, F>(mul_fn: F)
 where
-    F: Fn(&Poly<MAX_POLY_DEGREE>, &Poly<MAX_POLY_DEGREE>) -> Poly<MAX_POLY_DEGREE>,
+    F: Fn(&Poly<C>, &Poly<C>) -> Poly<C>,
 {
-    let p1: Poly<MAX_POLY_DEGREE> = rand_poly(MAX_POLY_DEGREE - 1);
+    let p1: Poly<C> = rand_poly(C::MAX_POLY_DEGREE - 1);
 
     #[allow(clippy::int_plus_one)]
     {
-        assert!(p1.degree() <= MAX_POLY_DEGREE - 1);
+        assert!(p1.degree() <= C::MAX_POLY_DEGREE - 1);
     }
 
     // Xˆ{N-1}, multiplying by it will rotate by N-1 and negate (except the first).
-    let xnm1 = Poly::xn(MAX_POLY_DEGREE - 1);
+    let xnm1 = Poly::xn(C::MAX_POLY_DEGREE - 1);
 
-    assert_eq!(xnm1.degree(), MAX_POLY_DEGREE - 1);
+    assert_eq!(xnm1.degree(), C::MAX_POLY_DEGREE - 1);
 
     let res = mul_fn(&p1, &xnm1);
-    assert!(res.degree() <= MAX_POLY_DEGREE);
+    assert!(res.degree() <= C::MAX_POLY_DEGREE);
 
-    for i in 0..MAX_POLY_DEGREE - 1 {
+    for i in 0..C::MAX_POLY_DEGREE - 1 {
         // Negative numbers are automatically converted to canonical
         // representation in the interval [0, MODULUS)
         assert_eq!(res[i], -p1[i + 1]);
     }
-    assert_eq!(res[MAX_POLY_DEGREE - 1], p1[0]);
+    assert_eq!(res[C::MAX_POLY_DEGREE - 1], p1[0]);
 
     // Zero leading coefficients aren't stored.
     // `degree()` panics if the leading coefficient is zero anyway.
-    assert!(res.degree() < MAX_POLY_DEGREE);
+    assert!(res.degree() < C::MAX_POLY_DEGREE);
 }
 
-/// Test cyclotomic multiplication that results in `X^[MAX_POLY_DEGREE]`.
+/// Test cyclotomic multiplication that results in `X^[C::MAX_POLY_DEGREE]`.
 #[test]
 fn test_cyclotomic_mul_max_degree() {
     check_cyclotomic_mul_max_degree::<FULL_RES_POLY_DEGREE, _>(naive_cyclotomic_mul);
@@ -56,23 +56,23 @@ fn test_cyclotomic_mul_max_degree() {
     check_cyclotomic_mul_max_degree::<FULL_RES_POLY_DEGREE, _>(flat_karatsuba_mul);
 }
 
-/// Check `mul_fn` correctly implements cyclotomic multiplication that results in `X^[MAX_POLY_DEGREE]`.
-fn check_cyclotomic_mul_max_degree<const MAX_POLY_DEGREE: usize, F>(mul_fn: F)
+/// Check `mul_fn` correctly implements cyclotomic multiplication that results in `X^[C::MAX_POLY_DEGREE]`.
+fn check_cyclotomic_mul_max_degree<C: PolyConf, F>(mul_fn: F)
 where
-    F: Fn(&Poly<MAX_POLY_DEGREE>, &Poly<MAX_POLY_DEGREE>) -> Poly<MAX_POLY_DEGREE>,
+    F: Fn(&Poly<C>, &Poly<C>) -> Poly<C>,
 {
-    // X^MAX_POLY_DEGREE
+    // X^C::MAX_POLY_DEGREE
     //
-    // Create a polynomial with degree equal to MAX_POLY_DEGREE.
+    // Create a polynomial with degree equal to C::MAX_POLY_DEGREE.
     // We can't use the standard methods, because we want an un-reduced polynomial.
     // But it is in canonical form, because the leading coefficient is non-zero.
-    let mut x_max: Poly<MAX_POLY_DEGREE> = Poly::zero();
-    x_max[MAX_POLY_DEGREE] = Coeff::one();
+    let mut x_max: Poly<C> = Poly::zero();
+    x_max[C::MAX_POLY_DEGREE] = Coeff::one();
 
     // Manually calculate the reduced representation of X^N as the constant `MODULUS - 1`.
     let (q, x_max) = x_max
-        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<MAX_POLY_DEGREE>())
-        .expect("is divisible by X^MAX_POLY_DEGREE");
+        .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<C>())
+        .expect("is divisible by X^C::MAX_POLY_DEGREE");
 
     assert_eq!(q, Poly::from_coefficients_vec(vec![Coeff::one()]));
     assert_eq!(
@@ -81,40 +81,40 @@ where
         Poly::from_coefficients_vec(vec![Coeff::zero() - Coeff::one()]),
     );
 
-    for i in 0..=MAX_POLY_DEGREE {
+    for i in 0..=C::MAX_POLY_DEGREE {
         // This test is slow, so skip most values.
         if i % 101 != 0
             && ![
                 0,
                 1,
-                MAX_POLY_DEGREE / 2 - 1,
-                MAX_POLY_DEGREE / 2,
-                MAX_POLY_DEGREE / 2 + 1,
-                MAX_POLY_DEGREE - 1,
-                MAX_POLY_DEGREE,
+                C::MAX_POLY_DEGREE / 2 - 1,
+                C::MAX_POLY_DEGREE / 2,
+                C::MAX_POLY_DEGREE / 2 + 1,
+                C::MAX_POLY_DEGREE - 1,
+                C::MAX_POLY_DEGREE,
             ]
             .contains(&i)
         {
             continue;
         }
 
-        // X^i * X^{MAX_POLY_DEGREE - i} = X^MAX_POLY_DEGREE
+        // X^i * X^{C::MAX_POLY_DEGREE - i} = X^C::MAX_POLY_DEGREE
 
         // `p1` and `p2` are automatically reduced if needed.
         let p1 = Poly::xn(i);
-        let p2 = Poly::xn(MAX_POLY_DEGREE - i);
+        let p2 = Poly::xn(C::MAX_POLY_DEGREE - i);
 
         if i == 0 || i == FULL_RES_POLY_DEGREE {
             assert_eq!(p1.degree(), 0);
             assert_eq!(p2.degree(), 0);
         } else {
-            assert_eq!(p1.degree() + p2.degree(), MAX_POLY_DEGREE);
+            assert_eq!(p1.degree() + p2.degree(), C::MAX_POLY_DEGREE);
         }
 
         let res = mul_fn(&p1, &p2);
 
         // Make sure it's X^N
-        assert_eq!(res, x_max, "x^{i} * x^{}", MAX_POLY_DEGREE - i);
+        assert_eq!(res, x_max, "x^{i} * x^{}", C::MAX_POLY_DEGREE - i);
     }
 }
 

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -121,8 +121,8 @@ where
 /// Test recursive karatsuba, flat karatsuba, and naive cyclotomic multiplication of two random polynomials all produce the same result.
 #[test]
 fn test_karatsuba_mul_rand_consistent() {
-    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE - 1);
-    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE - 1);
+    let p1: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE - 1);
+    let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE - 1);
 
     #[allow(clippy::int_plus_one)]
     {

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -5,7 +5,7 @@ use ark_poly::Polynomial;
 
 use crate::primitives::poly::{
     flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
-    test::gen::rand_poly, Coeff, Poly, FULL_RES_POLY_DEGREE,
+    test::gen::rand_poly, Coeff, Poly, PolyConf, FULL_RES_POLY_DEGREE,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -11,9 +11,9 @@ use crate::primitives::poly::{
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
 #[test]
 fn test_cyclotomic_mul_rand_xnm1() {
-    check_cyclotomic_mul_rand_xnm1::<FULL_RES_POLY_DEGREE, _>(naive_cyclotomic_mul);
-    check_cyclotomic_mul_rand_xnm1::<FULL_RES_POLY_DEGREE, _>(rec_karatsuba_mul);
-    check_cyclotomic_mul_rand_xnm1::<FULL_RES_POLY_DEGREE, _>(flat_karatsuba_mul);
+    check_cyclotomic_mul_rand_xnm1::<TestRes, _>(naive_cyclotomic_mul);
+    check_cyclotomic_mul_rand_xnm1::<TestRes, _>(rec_karatsuba_mul);
+    check_cyclotomic_mul_rand_xnm1::<TestRes, _>(flat_karatsuba_mul);
 }
 
 /// Check `mul_fn` correctly implements cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
@@ -51,9 +51,9 @@ where
 /// Test cyclotomic multiplication that results in `X^[C::MAX_POLY_DEGREE]`.
 #[test]
 fn test_cyclotomic_mul_max_degree() {
-    check_cyclotomic_mul_max_degree::<FULL_RES_POLY_DEGREE, _>(naive_cyclotomic_mul);
-    check_cyclotomic_mul_max_degree::<FULL_RES_POLY_DEGREE, _>(rec_karatsuba_mul);
-    check_cyclotomic_mul_max_degree::<FULL_RES_POLY_DEGREE, _>(flat_karatsuba_mul);
+    check_cyclotomic_mul_max_degree::<TestRes, _>(naive_cyclotomic_mul);
+    check_cyclotomic_mul_max_degree::<TestRes, _>(rec_karatsuba_mul);
+    check_cyclotomic_mul_max_degree::<TestRes, _>(flat_karatsuba_mul);
 }
 
 /// Check `mul_fn` correctly implements cyclotomic multiplication that results in `X^[C::MAX_POLY_DEGREE]`.
@@ -121,8 +121,8 @@ where
 /// Test recursive karatsuba, flat karatsuba, and naive cyclotomic multiplication of two random polynomials all produce the same result.
 #[test]
 fn test_karatsuba_mul_rand_consistent() {
-    let p1: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE - 1);
-    let p2: Poly<FULL_RES_POLY_DEGREE> = rand_poly(FULL_RES_POLY_DEGREE - 1);
+    let p1: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE - 1);
+    let p2: Poly<TestRes> = rand_poly(FULL_RES_POLY_DEGREE - 1);
 
     #[allow(clippy::int_plus_one)]
     {

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -5,7 +5,7 @@ use ark_poly::Polynomial;
 
 use crate::primitives::poly::{
     flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
-    test::gen::rand_poly, Coeff, Poly, PolyConf, FULL_RES_POLY_DEGREE,
+    test::gen::rand_poly, Coeff, Poly, PolyConf, TestRes, FULL_RES_POLY_DEGREE,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.

--- a/eyelid-match-ops/src/primitives/yashe.rs
+++ b/eyelid-match-ops/src/primitives/yashe.rs
@@ -1,6 +1,8 @@
 //! Implementation of YASHE cryptosystem
 //! `<https://eprint.iacr.org/2013/075.pdf>`
 
+use std::marker::PhantomData;
+
 use ark_ff::{One, UniformRand};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Normal};
@@ -23,7 +25,11 @@ pub struct YasheParams {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Yashe<C: PolyConf> {
     /// Cryptosystem parameters
+    /// TODO: turn these into a trait and marker type, with a `PolyConf` type in the cryptosystem trait
     params: YasheParams,
+
+    /// A zero-sized marker, which binds the config type to the outer type.
+    _conf: PhantomData<C>,
 }
 
 /// Private key struct
@@ -47,7 +53,10 @@ pub struct PublicKey<C: PolyConf> {
 impl<C: PolyConf> Yashe<C> {
     /// Yashe constructor
     pub fn new(params: YasheParams) -> Self {
-        Self { params }
+        Self {
+            params,
+            _conf: PhantomData,
+        }
     }
 
     /// Generate the private key

--- a/eyelid-match-ops/src/primitives/yashe.rs
+++ b/eyelid-match-ops/src/primitives/yashe.rs
@@ -5,7 +5,7 @@ use ark_ff::{One, UniformRand};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Normal};
 
-use crate::primitives::poly::{Coeff, Poly};
+use crate::primitives::poly::{Coeff, Poly, PolyConf};
 
 #[cfg(test)]
 pub mod test;
@@ -89,10 +89,7 @@ impl<C: PolyConf> Yashe<C> {
     }
 
     /// Generate the key pair
-    pub fn keygen(
-        &self,
-        rng: &mut ThreadRng,
-    ) -> (PrivateKey<C>, PublicKey<C>) {
+    pub fn keygen(&self, rng: &mut ThreadRng) -> (PrivateKey<C>, PublicKey<C>) {
         let priv_key = self.generate_private_key(rng);
         let pub_key = self.generate_public_key(rng, &priv_key);
         (priv_key, pub_key)

--- a/eyelid-match-ops/src/primitives/yashe.rs
+++ b/eyelid-match-ops/src/primitives/yashe.rs
@@ -1,13 +1,11 @@
 //! Implementation of YASHE cryptosystem
 //! `<https://eprint.iacr.org/2013/075.pdf>`
 
-use crate::primitives::poly::{
-    modular_poly::{inv::inverse, Poly},
-    Coeff,
-};
 use ark_ff::{One, UniformRand};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Normal};
+
+use crate::primitives::poly::{Coeff, Poly};
 
 #[cfg(test)]
 pub mod test;
@@ -56,7 +54,7 @@ impl<const MAX_POLY_DEGREE: usize> Yashe<MAX_POLY_DEGREE> {
     pub fn generate_private_key(&self, rng: &mut ThreadRng) -> PrivateKey<MAX_POLY_DEGREE> {
         loop {
             let f = self.sample_gaussian(rng);
-            let finv = inverse(&f);
+            let finv = f.inverse();
 
             let Ok(finv) = finv else {
                 continue;
@@ -67,7 +65,7 @@ impl<const MAX_POLY_DEGREE: usize> Yashe<MAX_POLY_DEGREE> {
             priv_key[0] += Coeff::one();
             priv_key.truncate_to_canonical_form();
 
-            let priv_key_inv = inverse(&priv_key);
+            let priv_key_inv = priv_key.inverse();
 
             if let Ok(_priv_key_inv) = priv_key_inv {
                 return PrivateKey { f, finv, priv_key };

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -42,5 +42,5 @@ fn keygen_helper<C: PolyConf>() {
 
 #[test]
 fn test_keygen() {
-    keygen_helper::<FULL_RES_POLY_DEGREE>();
+    keygen_helper::<TestRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -2,7 +2,7 @@
 
 use crate::primitives::{
     poly::FULL_RES_POLY_DEGREE,
-    yashe::{Coeff, Poly, Yashe, YasheParams},
+    yashe::{Coeff, Poly, PolyConf, Yashe, YasheParams},
 };
 use ark_ff::One;
 use ark_poly::Polynomial;

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -1,7 +1,7 @@
 //! Unit tests for Key Generation
 
 use crate::primitives::{
-    poly::FULL_RES_POLY_DEGREE,
+    poly::TestRes,
     yashe::{Coeff, Poly, PolyConf, Yashe, YasheParams},
 };
 use ark_ff::One;

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -8,7 +8,7 @@ use ark_ff::One;
 use ark_poly::Polynomial;
 
 /// Auxiliary function for testing key generation
-fn keygen_helper<const MAX_POLY_DEGREE: usize>() {
+fn keygen_helper<C: PolyConf>() {
     // TODO: how to deal with different sets of parameters?
     // We must be able to test all the different parameterizations
     let mut rng = rand::thread_rng();
@@ -16,7 +16,7 @@ fn keygen_helper<const MAX_POLY_DEGREE: usize>() {
         t: 1024,
         delta: 3.2,
     };
-    let ctx: Yashe<MAX_POLY_DEGREE> = Yashe::new(params);
+    let ctx: Yashe<C> = Yashe::new(params);
     let (private_key, public_key) = ctx.keygen(&mut rng);
 
     let f_inv = private_key.f.inverse();
@@ -37,7 +37,7 @@ fn keygen_helper<const MAX_POLY_DEGREE: usize>() {
         Poly::one()
     );
 
-    assert!(public_key.h.degree() < MAX_POLY_DEGREE);
+    assert!(public_key.h.degree() < C::MAX_POLY_DEGREE);
 }
 
 #[test]

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -1,7 +1,7 @@
 //! Unit tests for Key Generation
 
 use crate::primitives::{
-    poly::{modular_poly::inv::inverse, FULL_RES_POLY_DEGREE},
+    poly::FULL_RES_POLY_DEGREE,
     yashe::{Coeff, Poly, Yashe, YasheParams},
 };
 use ark_ff::One;
@@ -19,8 +19,8 @@ fn keygen_helper<const MAX_POLY_DEGREE: usize>() {
     let ctx: Yashe<MAX_POLY_DEGREE> = Yashe::new(params);
     let (private_key, public_key) = ctx.keygen(&mut rng);
 
-    let f_inv = inverse(&private_key.f);
-    let priv_key_inv = inverse(&private_key.priv_key);
+    let f_inv = private_key.f.inverse();
+    let priv_key_inv = private_key.priv_key.inverse();
 
     //dbg!(private_key.priv_key[0].clone());
     assert_eq!(


### PR DESCRIPTION
This PR depends on #65.

It is an extremely large change, so it would help to get it merged within a day or two. Otherwise it will conflict with other PRs. It is not easy to re-do, due to the number of manual fixes required.

This PR replaces the `MAX_POLY_DEGREE` const generic with a `PolyConf` trait containing a `MAX_POLY_DEGREE` constant.

It also makes a bunch of associated fixes and replacements:
- FULL_RES_POLY_DEGREE becomes TestRes
- IRIS_BIT_LENGTH becomes IrisBits
- There are new FullRes and TinyTest config types, which are currently only used in tests
- Some automatic derives can't be used, and need to be re-implemented manually
- Some code is cleaned up to make this change simpler

The mass replaces follow these instructions:
https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/mass-renames.md#universal-renames-with-sed

This is part of #59, but I'm going to replace `Coeff` in another PR.