### PR TITLE
1. Make `Coeff` into an associated type of the `PolyConf` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ark-poly = "0.4.2"
 ark-std = "0.4.0"
 
 bitvec = "1.0.1"
+
 # Automatically deriving trivial impls
 # Full list at <https://github.com/JelteF/derive_more/blob/v0.99.17/Cargo.toml#L42>
 # When we upgrade to 1.0.0, it will be at <https://github.com/JelteF/derive_more/blob/master/Cargo.toml#L49>

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -3,7 +3,7 @@
 //! - [`Poly`] is in [`modular_poly`] and its submodules,
 //! - `Fq*` coefficient types are in [`fq`] and submodules.
 
-pub use fq::{Coeff, Fq79};
+pub use fq::{C::Coeff, Fq79};
 pub use modular_poly::{
     conf::PolyConf,
     modulus::{mod_poly, new_unreduced_poly_modulus_slow},

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -1,9 +1,9 @@
 //! Cyclotomic polynomials using ark-poly.
 //! This module file is import-only, code is in submodules:
 //! - [`Poly`] is in [`modular_poly`] and its submodules,
-//! - [`Coeff`] is in [`fq`] and submodules.
+//! - `Fq*` coefficient types are in [`fq`] and submodules.
 
-pub use fq::Coeff;
+pub use fq::{Coeff, Fq79, FqTiny};
 pub use modular_poly::{
     conf::PolyConf,
     modulus::{mod_poly, new_unreduced_poly_modulus_slow},

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -3,7 +3,7 @@
 //! - [`Poly`] is in [`modular_poly`] and its submodules,
 //! - `Fq*` coefficient types are in [`fq`] and submodules.
 
-pub use fq::{Coeff, Fq79, FqTiny};
+pub use fq::{Coeff, Fq79};
 pub use modular_poly::{
     conf::PolyConf,
     modulus::{mod_poly, new_unreduced_poly_modulus_slow},

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -3,7 +3,7 @@
 //! - [`Poly`] is in [`modular_poly`] and its submodules,
 //! - `Fq*` coefficient types are in [`fq`] and submodules.
 
-pub use fq::{C::Coeff, Fq79};
+pub use fq::Fq79;
 pub use modular_poly::{
     conf::PolyConf,
     modulus::{mod_poly, new_unreduced_poly_modulus_slow},

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -1,19 +1,23 @@
 //! The underlying integer field.
 //!
-//! Outside this module, use [`PolyConf::Coeff`] instead of [`Fq79`] or [`FqTiny`].
+//! Outside this module, use [`PolyConf::Coeff`] instead of [`Fq79`] or `FqTiny`.
 //! This automatically enables CI tests on both fields.
-
-pub use fq79::Fq79;
-pub use fq_tiny::Fq4 as FqTiny;
 
 use ark_ff::Zero;
 use lazy_static::lazy_static;
+
+pub use fq79::Fq79;
 
 // Doc links only
 #[allow(unused_imports)]
 use crate::primitives::poly::PolyConf;
 
+#[cfg(tiny_poly)]
+pub use fq_tiny::Fq4 as FqTiny;
+
 mod fq79;
+
+#[cfg(tiny_poly)]
 mod fq_tiny;
 
 #[cfg(not(tiny_poly))]

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -3,9 +3,6 @@
 //! Outside this module, use [`PolyConf::Coeff`] instead of [`Fq79`] or `FqTiny`.
 //! This automatically enables CI tests on both fields.
 
-use ark_ff::Zero;
-use lazy_static::lazy_static;
-
 pub use fq79::Fq79;
 
 // Doc links only
@@ -20,31 +17,10 @@ mod fq79;
 #[cfg(tiny_poly)]
 mod fq_tiny;
 
+// TODO: delete this after Coeff is generic
 #[cfg(not(tiny_poly))]
 pub use fq79::Coeff;
 
-// Temporarily switch to this tiny field to make test errors easier to debug:
-// ```no_run
-// RUSTFLAGS="--cfg tiny_poly" cargo test
-// RUSTFLAGS="--cfg tiny_poly" cargo bench --features benchmark
-// ```
+// TODO: delete this after Coeff is generic
 #[cfg(tiny_poly)]
 pub use fq_tiny::Coeff;
-
-lazy_static! {
-    /// The zero coefficient as a static constant value.
-    ///
-    /// # Usage
-    ///
-    /// Return `&super::fq::COEFF_ZERO` from a function that returns a reference to `Coeff::zero()`.
-    ///
-    /// Only use this constant when you need a long-lived reference to a zero coefficient value.
-    /// The compiler will tell you, with errors like:
-    /// > cannot return reference to a temporary value
-    /// > returns a reference to data owned by the current function
-    ///
-    /// Typically, `Coeff::zero()` is more readable and efficient.
-    pub static ref COEFF_ZERO: Coeff = {
-        Coeff::zero()
-    };
-}

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -16,11 +16,3 @@ mod fq79;
 
 #[cfg(tiny_poly)]
 mod fq_tiny;
-
-// TODO: delete this after C::Coeff is generic
-#[cfg(not(tiny_poly))]
-pub use fq79::C::Coeff;
-
-// TODO: delete this after C::Coeff is generic
-#[cfg(tiny_poly)]
-pub use fq_tiny::C::Coeff;

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -1,6 +1,6 @@
 //! The underlying integer field.
 //!
-//! Outside this module, use [`PolyConf::C::Coeff`] instead of [`Fq79`] or `FqTiny`.
+//! Outside this module, use [`PolyConf::Coeff`] instead of [`Fq79`] or `FqTiny`.
 //! This automatically enables CI tests on both fields.
 
 pub use fq79::Fq79;

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -1,6 +1,6 @@
 //! The underlying integer field.
 //!
-//! Outside this module, use [`PolyConf::Coeff`] instead of [`Fq79`] or `FqTiny`.
+//! Outside this module, use [`PolyConf::C::Coeff`] instead of [`Fq79`] or `FqTiny`.
 //! This automatically enables CI tests on both fields.
 
 pub use fq79::Fq79;
@@ -17,10 +17,10 @@ mod fq79;
 #[cfg(tiny_poly)]
 mod fq_tiny;
 
-// TODO: delete this after Coeff is generic
+// TODO: delete this after C::Coeff is generic
 #[cfg(not(tiny_poly))]
-pub use fq79::Coeff;
+pub use fq79::C::Coeff;
 
-// TODO: delete this after Coeff is generic
+// TODO: delete this after C::Coeff is generic
 #[cfg(tiny_poly)]
-pub use fq_tiny::Coeff;
+pub use fq_tiny::C::Coeff;

--- a/eyelid-match-ops/src/primitives/poly/fq.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq.rs
@@ -1,10 +1,17 @@
 //! The underlying integer field.
 //!
-//! Outside this module, use [`fq::Coeff`](Coeff) instead of `fq79` or `fq_tiny`.
+//! Outside this module, use [`PolyConf::Coeff`] instead of [`Fq79`] or [`FqTiny`].
 //! This automatically enables CI tests on both fields.
+
+pub use fq79::Fq79;
+pub use fq_tiny::Fq4 as FqTiny;
 
 use ark_ff::Zero;
 use lazy_static::lazy_static;
+
+// Doc links only
+#[allow(unused_imports)]
+use crate::primitives::poly::PolyConf;
 
 mod fq79;
 mod fq_tiny;

--- a/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
@@ -3,11 +3,10 @@
 //! These are the parameters for full resolution, according to the Inversed Tech report.
 //! t = 2ˆ15, q = 2ˆ79
 
-#![cfg_attr(tiny_poly, allow(dead_code))]
-
 use ark_ff::{Fp128, MontBackend, MontConfig};
 
 /// The modular field used for polynomial coefficients, with precomputed primes and generators.
+/// TODO: delete this alias as part of cleanup.
 pub type Coeff = Fq79;
 
 /// The configuration of the modular field used for polynomial coefficients.

--- a/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
@@ -7,7 +7,7 @@ use ark_ff::{Fp128, MontBackend, MontConfig};
 
 /// The modular field used for polynomial coefficients, with precomputed primes and generators.
 /// TODO: delete this alias as part of cleanup.
-pub type Coeff = Fq79;
+pub type C::Coeff = Fq79;
 
 /// The configuration of the modular field used for polynomial coefficients.
 //

--- a/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
@@ -5,10 +5,6 @@
 
 use ark_ff::{Fp128, MontBackend, MontConfig};
 
-/// The modular field used for polynomial coefficients, with precomputed primes and generators.
-/// TODO: delete this alias as part of cleanup.
-pub type C::Coeff = Fq79;
-
 /// The configuration of the modular field used for polynomial coefficients.
 //
 // Sage commands:

--- a/eyelid-match-ops/src/primitives/poly/fq/fq_tiny.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq/fq_tiny.rs
@@ -3,12 +3,7 @@
 //! These test parameters are specifically chosen to make failing tests easy to read and diagnose.
 //! q = 2ˆ4
 
-#![cfg_attr(not(tiny_poly), allow(dead_code))]
-
 use ark_ff::{Fp64, MontBackend, MontConfig};
-
-/// The modular field used for test polynomial coefficients, with precomputed primes and generators.
-pub type Coeff = Fq4;
 
 /// The configuration of the test-only modular field, used for polynomial coefficients.
 ///

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -22,9 +22,7 @@ use ark_poly::polynomial::univariate::{
 };
 use derive_more::{AsRef, Deref, DerefMut, Div, Into, Rem};
 
-use crate::primitives::poly::{
-    mod_poly, mul_poly, new_unreduced_poly_modulus_slow, C::Coeff, PolyConf,
-};
+use crate::primitives::poly::{mod_poly, mul_poly, new_unreduced_poly_modulus_slow, PolyConf};
 
 pub mod conf;
 
@@ -34,8 +32,8 @@ pub(super) mod mul;
 
 mod trivial;
 
-/// A modular polynomial with coefficients in [`C::Coeff`], and a generic maximum degree
-/// `C::MAX_POLY_DEGREE`. The un-reduced polynomial modulus is the polynomial modulus. TODO
+/// A modular polynomial with coefficients in [`PolyConf::Coeff`], and a generic maximum degree
+/// [`PolyConf::MAX_POLY_DEGREE`]. The un-reduced polynomial modulus is the polynomial modulus. TODO
 ///
 /// In its canonical form, a polynomial is a list of coefficients from the constant term `X^0`
 /// to the degree `X^n`, where the highest coefficient is non-zero. Leading zero coefficients are
@@ -194,7 +192,7 @@ impl<C: PolyConf> Poly<C> {
     }
 
     /// Reduce this polynomial so it is less than the polynomial modulus.
-    /// This also ensures its degree is less than [`C::MAX_POLY_DEGREE`](Self::N).
+    /// This also ensures its degree is less than [[`PolyConf::MAX_POLY_DEGREE`]](Self::N).
     ///
     /// This operation should be performed after every [`Poly`] method that increases the degree of the polynomial.
     /// [`DensePolynomial`] methods *do not* do this reduction.
@@ -282,7 +280,7 @@ impl<C: PolyConf> Index<usize> for Poly<C> {
     ///
     /// Only panics if index is:
     /// - a leading zero coefficient (which is not represented in the underlying data), and
-    /// - above [`C::MAX_POLY_DEGREE`](Self::N).
+    /// - above [[`PolyConf::MAX_POLY_DEGREE`]](Self::N).
     ///
     /// Panics indicate redundant code which should have stopped at the highest non-zero
     /// coefficient. Using `self.coeffs.iter()` is one way to ensure the code only accesses real

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -7,7 +7,7 @@
 
 // Optional TODOs:
 // - re-implement IndexMut manually, to enforce the canonical form (highest coefficient is non-zero) and modular arithmetic
-//   (this can be done by returning a new type with `DerefMut<Target = Coeff>``, but it could have performance impacts)
+//   (this can be done by returning a new type with `DerefMut<Target = C::Coeff>``, but it could have performance impacts)
 // Trivial:
 // - implement Sum manually
 
@@ -23,7 +23,7 @@ use ark_poly::polynomial::univariate::{
 use derive_more::{AsRef, Deref, DerefMut, Div, Into, Rem};
 
 use crate::primitives::poly::{
-    mod_poly, mul_poly, new_unreduced_poly_modulus_slow, Coeff, PolyConf,
+    mod_poly, mul_poly, new_unreduced_poly_modulus_slow, C::Coeff, PolyConf,
 };
 
 pub mod conf;
@@ -34,7 +34,7 @@ pub(super) mod mul;
 
 mod trivial;
 
-/// A modular polynomial with coefficients in [`Coeff`], and a generic maximum degree
+/// A modular polynomial with coefficients in [`C::Coeff`], and a generic maximum degree
 /// `C::MAX_POLY_DEGREE`. The un-reduced polynomial modulus is the polynomial modulus. TODO
 ///
 /// In its canonical form, a polynomial is a list of coefficients from the constant term `X^0`
@@ -67,7 +67,7 @@ pub struct Poly<C: PolyConf>(
     /// The inner polynomial.
     #[deref]
     #[deref_mut]
-    DensePolynomial<Coeff>,
+    DensePolynomial<C::Coeff>,
     /// A zero-sized marker, which binds the config type to the outer polynomial type.
     PhantomData<C>,
 );
@@ -79,14 +79,14 @@ impl<C: PolyConf> Poly<C> {
     // Shadow DenseUVPolynomial methods, so we don't have to implement Polynomial and all its supertraits.
 
     /// Converts the `coeffs` vector into a dense polynomial.
-    pub fn from_coefficients_vec(coeffs: Vec<Coeff>) -> Self {
+    pub fn from_coefficients_vec(coeffs: Vec<C::Coeff>) -> Self {
         let mut poly = Self(DensePolynomial { coeffs }, PhantomData);
         poly.truncate_to_canonical_form();
         poly
     }
 
     /// Converts the `coeffs` slice into a dense polynomial.
-    pub fn from_coefficients_slice(coeffs: &[Coeff]) -> Self {
+    pub fn from_coefficients_slice(coeffs: &[C::Coeff]) -> Self {
         Self::from_coefficients_vec(coeffs.to_vec())
     }
 
@@ -115,7 +115,7 @@ impl<C: PolyConf> Poly<C> {
     /// Returns `X^n` as a polynomial in reduced form.
     pub fn xn(n: usize) -> Self {
         let mut poly = Self::zero();
-        poly[n] = Coeff::one();
+        poly[n] = C::Coeff::one();
 
         poly.reduce_mod_poly();
 
@@ -125,7 +125,7 @@ impl<C: PolyConf> Poly<C> {
     /// Multiplies `self` by `X^n`, then reduces if needed.
     pub fn mul_xn(&mut self, n: usize) {
         // Insert `n` zeroes to the lowest coefficients of the polynomial, and shifts the rest up.
-        self.coeffs.splice(0..0, vec![Coeff::zero(); n]);
+        self.coeffs.splice(0..0, vec![C::Coeff::zero(); n]);
 
         self.reduce_mod_poly();
     }
@@ -207,7 +207,7 @@ impl<C: PolyConf> Poly<C> {
     /// This operation must be performed after every [`Poly`] method that changes the degree or coefficients of the polynomial.
     /// (`DensePolynomial` methods already do this.)
     pub fn truncate_to_canonical_form(&mut self) {
-        while self.coeffs.last() == Some(&Coeff::zero()) {
+        while self.coeffs.last() == Some(&C::Coeff::zero()) {
             self.coeffs.pop();
         }
     }
@@ -219,23 +219,23 @@ impl<C: PolyConf> Poly<C> {
     pub(crate) fn non_canonical_zeroes(n: usize) -> Self {
         Self(
             DensePolynomial {
-                coeffs: vec![Coeff::zero(); n],
+                coeffs: vec![C::Coeff::zero(); n],
             },
             PhantomData,
         )
     }
 }
 
-impl<C: PolyConf> From<DensePolynomial<Coeff>> for Poly<C> {
-    fn from(poly: DensePolynomial<Coeff>) -> Self {
+impl<C: PolyConf> From<DensePolynomial<C::Coeff>> for Poly<C> {
+    fn from(poly: DensePolynomial<C::Coeff>) -> Self {
         let mut poly = Self(poly, PhantomData);
         poly.reduce_mod_poly();
         poly
     }
 }
 
-impl<C: PolyConf> From<&DensePolynomial<Coeff>> for Poly<C> {
-    fn from(poly: &DensePolynomial<Coeff>) -> Self {
+impl<C: PolyConf> From<&DensePolynomial<C::Coeff>> for Poly<C> {
+    fn from(poly: &DensePolynomial<C::Coeff>) -> Self {
         let mut poly = Self(poly.clone(), PhantomData);
         poly.reduce_mod_poly();
         poly
@@ -243,32 +243,32 @@ impl<C: PolyConf> From<&DensePolynomial<Coeff>> for Poly<C> {
 }
 
 // These are less likely to be called, so it's ok to have sub-optimal performance.
-impl<C: PolyConf> From<SparsePolynomial<Coeff>> for Poly<C> {
-    fn from(poly: SparsePolynomial<Coeff>) -> Self {
+impl<C: PolyConf> From<SparsePolynomial<C::Coeff>> for Poly<C> {
+    fn from(poly: SparsePolynomial<C::Coeff>) -> Self {
         DensePolynomial::from(poly).into()
     }
 }
 
-impl<C: PolyConf> From<&SparsePolynomial<Coeff>> for Poly<C> {
-    fn from(poly: &SparsePolynomial<Coeff>) -> Self {
+impl<C: PolyConf> From<&SparsePolynomial<C::Coeff>> for Poly<C> {
+    fn from(poly: &SparsePolynomial<C::Coeff>) -> Self {
         DensePolynomial::from(poly.clone()).into()
     }
 }
 
-impl<'a, C: PolyConf> From<DenseOrSparsePolynomial<'a, Coeff>> for Poly<C> {
-    fn from(poly: DenseOrSparsePolynomial<'a, Coeff>) -> Self {
+impl<'a, C: PolyConf> From<DenseOrSparsePolynomial<'a, C::Coeff>> for Poly<C> {
+    fn from(poly: DenseOrSparsePolynomial<'a, C::Coeff>) -> Self {
         DensePolynomial::from(poly).into()
     }
 }
 
-impl<'a, C: PolyConf> From<&DenseOrSparsePolynomial<'a, Coeff>> for Poly<C> {
-    fn from(poly: &DenseOrSparsePolynomial<'a, Coeff>) -> Self {
+impl<'a, C: PolyConf> From<&DenseOrSparsePolynomial<'a, C::Coeff>> for Poly<C> {
+    fn from(poly: &DenseOrSparsePolynomial<'a, C::Coeff>) -> Self {
         DensePolynomial::from(poly.clone()).into()
     }
 }
 
 impl<C: PolyConf> Index<usize> for Poly<C> {
-    type Output = C::Coeff;
+    type Output = C::C::Coeff;
 
     /// Read the coefficient at `index`, panicking only when reading a leading zero index above
     /// the maximum degree.
@@ -318,7 +318,7 @@ impl<C: PolyConf> IndexMut<usize> for Poly<C> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         // Make sure there is a coefficient entry for `index`, but don't truncate if the index already exists.
         if index + 1 > self.coeffs.len() {
-            self.coeffs.resize(index + 1, Coeff::zero());
+            self.coeffs.resize(index + 1, C::Coeff::zero());
         }
 
         self.coeffs.get_mut(index).expect("just resized")
@@ -362,22 +362,22 @@ impl<C: PolyConf> Mul<Poly<C>> for &Poly<C> {
     }
 }
 
-impl<C: PolyConf> Mul<DensePolynomial<Coeff>> for Poly<C> {
+impl<C: PolyConf> Mul<DensePolynomial<C::Coeff>> for Poly<C> {
     type Output = Self;
 
     /// Multiplies then reduces by the polynomial modulus.
-    fn mul(self, rhs: DensePolynomial<Coeff>) -> Self {
+    fn mul(self, rhs: DensePolynomial<C::Coeff>) -> Self {
         mul_poly(&self, &Self(rhs, PhantomData))
     }
 }
 
 // TODO: if we need this method, remove the clone() using unsafe code
 #[cfg(inefficient)]
-impl<C: PolyConf> Mul<&DensePolynomial<Coeff>> for Poly<C> {
+impl<C: PolyConf> Mul<&DensePolynomial<C::Coeff>> for Poly<C> {
     type Output = Self;
 
     /// Multiplies then reduces by the polynomial modulus.
-    fn mul(self, rhs: &DensePolynomial<Coeff>) -> Self {
+    fn mul(self, rhs: &DensePolynomial<C::Coeff>) -> Self {
         mul_poly(&self, &Self(rhs.clone()), PhantomData)
     }
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -266,7 +266,7 @@ impl<'a, C: PolyConf> From<&DenseOrSparsePolynomial<'a, C::Coeff>> for Poly<C> {
 }
 
 impl<C: PolyConf> Index<usize> for Poly<C> {
-    type Output = C::C::Coeff;
+    type Output = C::Coeff;
 
     /// Read the coefficient at `index`, panicking only when reading a leading zero index above
     /// the maximum degree.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -268,7 +268,7 @@ impl<'a, C: PolyConf> From<&DenseOrSparsePolynomial<'a, Coeff>> for Poly<C> {
 }
 
 impl<C: PolyConf> Index<usize> for Poly<C> {
-    type Output = Coeff;
+    type Output = C::Coeff;
 
     /// Read the coefficient at `index`, panicking only when reading a leading zero index above
     /// the maximum degree.
@@ -296,7 +296,7 @@ impl<C: PolyConf> Index<usize> for Poly<C> {
             Some(coeff) => coeff,
             None => {
                 if index <= C::MAX_POLY_DEGREE {
-                    &super::fq::COEFF_ZERO
+                    C::coeff_zero()
                 } else {
                     panic!("accessed virtual leading zero coefficient: improve performance by stopping at the highest non-zero coefficient")
                 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -107,7 +107,7 @@ impl PolyConf for TinyTest {
     type Coeff = FqTiny;
 
     fn coeff_zero() -> &'static Self::Coeff {
-        &*FQ_TINY_ZERO
+        &FQ_TINY_ZERO
     }
 }
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -7,6 +7,9 @@ use lazy_static::lazy_static;
 
 use crate::primitives::poly::Fq79;
 
+#[cfg(tiny_poly)]
+use crate::primitives::poly::fq::FqTiny;
+
 /// The polynomial config used in tests.
 //
 // We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -60,12 +60,13 @@ impl PolyConf for IrisBits {
     type Coeff = Fq79;
 
     fn coeff_zero() -> &'static Self::Coeff {
-        &*FQ79_ZERO
+        &FQ79_ZERO
     }
 }
 
 lazy_static! {
-    pub static ref FQ79_ZERO: Fq79 = Fq79::zero();
+    /// The zero coefficient as a static constant value.
+    static ref FQ79_ZERO: Fq79 = Fq79::zero();
 }
 
 // TODO: try generic_singleton and see if it performs better:
@@ -85,7 +86,7 @@ impl PolyConf for FullRes {
     type Coeff = Fq79;
 
     fn coeff_zero() -> &'static Self::Coeff {
-        &*FQ79_ZERO
+        &FQ79_ZERO
     }
 }
 
@@ -109,5 +110,6 @@ impl PolyConf for TinyTest {
 
 #[cfg(tiny_poly)]
 lazy_static! {
-    pub static ref FQ_TINY_ZERO: FqTiny = FqTiny::zero();
+    /// The zero coefficient as a static constant value.
+    static ref FQ_TINY_ZERO: FqTiny = FqTiny::zero();
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Debug;
 
+use crate::primitives::poly::Fq79;
+
 /// The polynomial config used in tests.
 //
 // We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
@@ -19,7 +21,8 @@ pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
     /// The maximum exponent in the polynomial.
     const MAX_POLY_DEGREE: usize;
 
-    // TODO: add Coeff type
+    /// The type of the coefficient.
+    type Coeff: ark_ff::PrimeField;
 }
 
 /// Iris bit length polynomial parameters.
@@ -30,6 +33,7 @@ pub struct IrisBits;
 
 impl PolyConf for IrisBits {
     const MAX_POLY_DEGREE: usize = crate::IRIS_BIT_LENGTH;
+    type Coeff = Fq79;
 }
 
 /// Full resolution polynomial parameters.
@@ -42,6 +46,7 @@ pub struct FullRes;
 #[cfg(not(tiny_poly))]
 impl PolyConf for FullRes {
     const MAX_POLY_DEGREE: usize = 2048;
+    type Coeff = Fq79;
 }
 
 /// Tiny test polynomials, used for finding edge cases in tests.
@@ -54,4 +59,5 @@ pub struct TinyTest;
 #[cfg(tiny_poly)]
 impl PolyConf for TinyTest {
     const MAX_POLY_DEGREE: usize = 8;
+    type Coeff = FqTiny;
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
@@ -2,7 +2,7 @@
 use ark_ff::{Field, One, Zero};
 use ark_poly::Polynomial;
 
-use crate::primitives::poly::{C::Coeff, Poly, PolyConf};
+use crate::primitives::poly::{Poly, PolyConf};
 
 /// Returns the primitive polynomial which is the inverse of `a` in the
 /// cyclotomic ring, if it exists. Otherwise, returns an error.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/inv.rs
@@ -2,7 +2,7 @@
 use ark_ff::{Field, One, Zero};
 use ark_poly::Polynomial;
 
-use crate::primitives::poly::{Coeff, Poly, PolyConf};
+use crate::primitives::poly::{C::Coeff, Poly, PolyConf};
 
 /// Returns the primitive polynomial which is the inverse of `a` in the
 /// cyclotomic ring, if it exists. Otherwise, returns an error.
@@ -30,7 +30,7 @@ pub fn inverse<C: PolyConf>(a: &Poly<C>) -> Result<Poly<C>, &'static str> {
         // Reduce to a primitive polynomial.
         let mut inv: Poly<C> = y;
         // Compute the inverse of the content
-        let content_inv: Coeff = d[0].inverse().expect("just checked for zero");
+        let content_inv: C::Coeff = d[0].inverse().expect("just checked for zero");
         // Divide by `content_inv`
         inv *= content_inv;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -3,7 +3,7 @@
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::Polynomial;
 
-use crate::primitives::poly::{Coeff, Poly, PolyConf};
+use crate::primitives::poly::{C::Coeff, Poly, PolyConf};
 
 /// The fastest available modular polynomial operation.
 pub use mod_poly_manual_mut as mod_poly;
@@ -80,8 +80,8 @@ pub fn new_unreduced_poly_modulus_slow<C: PolyConf>() -> Poly<C> {
 
     // Since the leading coefficient is non-zero, this is in canonical form.
     // Resize to the maximum size first, to avoid repeated reallocations.
-    poly[C::MAX_POLY_DEGREE] = Coeff::one();
-    poly[0] = Coeff::one();
+    poly[C::MAX_POLY_DEGREE] = C::Coeff::one();
+    poly[0] = C::Coeff::one();
 
     // Check canonicity and degree.
     assert_eq!(poly.degree(), C::MAX_POLY_DEGREE);

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -3,7 +3,7 @@
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::Polynomial;
 
-use crate::primitives::poly::{C::Coeff, Poly, PolyConf};
+use crate::primitives::poly::{Poly, PolyConf};
 
 /// The fastest available modular polynomial operation.
 pub use mod_poly_manual_mut as mod_poly;

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
@@ -9,7 +9,7 @@ use static_assertions::const_assert_eq;
 use crate::primitives::poly::{
     mod_poly,
     modular_poly::modulus::{mod_poly_ark_ref_slow, mod_poly_manual_mut},
-    C::Coeff, Poly, PolyConf,
+    Poly, PolyConf,
 };
 
 // Simple multiplication by a field element.
@@ -56,7 +56,7 @@ pub const FLAT_KARATSUBA_INITIAL_LAYER: u32 = 3;
 pub const FLAT_KARATSUBA_INITIAL_LAYER: u32 = 2;
 
 /// Returns `a * b` followed by reduction mod `XˆN + 1`.
-/// All polynomials have maximum degree `C::MAX_POLY_DEGREE`.
+/// All polynomials have maximum degree [`PolyConf::MAX_POLY_DEGREE`].
 pub fn naive_cyclotomic_mul<C: PolyConf>(a: &Poly<C>, b: &Poly<C>) -> Poly<C> {
     debug_assert!(a.degree() <= C::MAX_POLY_DEGREE);
     debug_assert!(b.degree() <= C::MAX_POLY_DEGREE);
@@ -94,7 +94,7 @@ pub fn naive_cyclotomic_mul<C: PolyConf>(a: &Poly<C>, b: &Poly<C>) -> Poly<C> {
 }
 
 /// Returns `a * b` followed by reduction mod `XˆN + 1` using recursive Karatsuba method.
-/// All polynomials have maximum degree `C::MAX_POLY_DEGREE`.
+/// All polynomials have maximum degree [`PolyConf::MAX_POLY_DEGREE`].
 ///
 /// # Performance
 ///
@@ -183,7 +183,7 @@ fn rec_karatsuba_mul_inner<C: PolyConf>(a: &Poly<C>, b: &Poly<C>, chunk: usize) 
 }
 
 /// Returns `a * b` followed by reduction mod `XˆN + 1` using flat Karatsuba method.
-/// The returned polynomial has a degree less than `C::MAX_POLY_DEGREE`.
+/// The returned polynomial has a degree less than [`PolyConf::MAX_POLY_DEGREE`].
 ///
 /// This implementation can be parallelized since for each layer
 /// we have that chunks are independent of each other.
@@ -340,7 +340,7 @@ pub fn poly_split<C: PolyConf>(a: &Poly<C>, k: usize) -> Vec<Poly<C>> {
 ///
 /// Returns `(low, high)`, where `low` contains the constant term.
 ///
-/// All polynomials have maximum degree `C::MAX_POLY_DEGREE`. The modulus remains the same even after
+/// All polynomials have maximum degree [`PolyConf::MAX_POLY_DEGREE`]. The modulus remains the same even after
 /// the split.
 pub fn poly_split_half<C: PolyConf>(a: &Poly<C>, chunk: usize) -> (Poly<C>, Poly<C>) {
     debug_assert!(chunk <= C::MAX_POLY_DEGREE);

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/mul.rs
@@ -9,21 +9,21 @@ use static_assertions::const_assert_eq;
 use crate::primitives::poly::{
     mod_poly,
     modular_poly::modulus::{mod_poly_ark_ref_slow, mod_poly_manual_mut},
-    Coeff, Poly, PolyConf,
+    C::Coeff, Poly, PolyConf,
 };
 
 // Simple multiplication by a field element.
 
-impl<C: PolyConf> MulAssign<Coeff> for Poly<C> {
-    fn mul_assign(&mut self, rhs: Coeff) {
+impl<C: PolyConf> MulAssign<C::Coeff> for Poly<C> {
+    fn mul_assign(&mut self, rhs: C::Coeff) {
         for coeff in &mut self.0.coeffs {
             *coeff *= rhs;
         }
     }
 }
 
-impl<C: PolyConf> MulAssign<Coeff> for &mut Poly<C> {
-    fn mul_assign(&mut self, rhs: Coeff) {
+impl<C: PolyConf> MulAssign<C::Coeff> for &mut Poly<C> {
+    fn mul_assign(&mut self, rhs: C::Coeff) {
         for coeff in &mut self.0.coeffs {
             *coeff *= rhs;
         }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -12,22 +12,22 @@ use std::{
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::univariate::{DenseOrSparsePolynomial, DensePolynomial};
 
-use crate::primitives::poly::{modular_poly::Poly, Coeff, PolyConf};
+use crate::primitives::poly::{modular_poly::Poly, C::Coeff, PolyConf};
 
-impl<C: PolyConf> Borrow<DensePolynomial<Coeff>> for Poly<C> {
-    fn borrow(&self) -> &DensePolynomial<Coeff> {
+impl<C: PolyConf> Borrow<DensePolynomial<C::Coeff>> for Poly<C> {
+    fn borrow(&self) -> &DensePolynomial<C::Coeff> {
         &self.0
     }
 }
 
-impl<C: PolyConf> From<Poly<C>> for DenseOrSparsePolynomial<'static, Coeff> {
-    fn from(poly: Poly<C>) -> DenseOrSparsePolynomial<'static, Coeff> {
+impl<C: PolyConf> From<Poly<C>> for DenseOrSparsePolynomial<'static, C::Coeff> {
+    fn from(poly: Poly<C>) -> DenseOrSparsePolynomial<'static, C::Coeff> {
         poly.0.into()
     }
 }
 
-impl<'a, C: PolyConf> From<&'a Poly<C>> for DenseOrSparsePolynomial<'a, Coeff> {
-    fn from(poly: &'a Poly<C>) -> DenseOrSparsePolynomial<'a, Coeff> {
+impl<'a, C: PolyConf> From<&'a Poly<C>> for DenseOrSparsePolynomial<'a, C::Coeff> {
+    fn from(poly: &'a Poly<C>) -> DenseOrSparsePolynomial<'a, C::Coeff> {
         (&poly.0).into()
     }
 }
@@ -45,16 +45,16 @@ impl<C: PolyConf> Zero for Poly<C> {
 impl<C: PolyConf> One for Poly<C> {
     fn one() -> Self {
         let mut poly = Self::zero();
-        poly[0] = Coeff::one();
+        poly[0] = C::Coeff::one();
         poly
     }
 
     fn set_one(&mut self) {
-        self.coeffs = vec![Coeff::one()];
+        self.coeffs = vec![C::Coeff::one()];
     }
 
     fn is_one(&self) -> bool {
-        self.coeffs == vec![Coeff::one()]
+        self.coeffs == vec![C::Coeff::one()]
     }
 }
 
@@ -161,18 +161,18 @@ impl<C: PolyConf> SubAssign<&Poly<C>> for Poly<C> {
 }
 
 // Multiplying by a scalar can't increase the degree, so it is trivial.
-impl<C: PolyConf> Mul<Coeff> for Poly<C> {
+impl<C: PolyConf> Mul<C::Coeff> for Poly<C> {
     type Output = Self;
 
-    fn mul(self, rhs: Coeff) -> Self {
+    fn mul(self, rhs: C::Coeff) -> Self {
         Poly(&self.0 * rhs, PhantomData)
     }
 }
 
-impl<C: PolyConf> Mul<Coeff> for &Poly<C> {
+impl<C: PolyConf> Mul<C::Coeff> for &Poly<C> {
     type Output = Poly<C>;
 
-    fn mul(self, rhs: Coeff) -> Self::Output {
+    fn mul(self, rhs: C::Coeff) -> Self::Output {
         Poly(&self.0 * rhs, PhantomData)
     }
 }

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -6,7 +6,7 @@
 use std::{
     borrow::Borrow,
     marker::PhantomData,
-    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 
 use ark_ff::{One, Zero};
@@ -160,19 +160,5 @@ impl<C: PolyConf> SubAssign<&Poly<C>> for Poly<C> {
     }
 }
 
-// Multiplying by a scalar can't increase the degree, so it is trivial.
-impl<C: PolyConf> Mul<C::Coeff> for Poly<C> {
-    type Output = Self;
-
-    fn mul(self, rhs: C::Coeff) -> Self {
-        Poly(&self.0 * rhs, PhantomData)
-    }
-}
-
-impl<C: PolyConf> Mul<C::Coeff> for &Poly<C> {
-    type Output = Poly<C>;
-
-    fn mul(self, rhs: C::Coeff) -> Self::Output {
-        Poly(&self.0 * rhs, PhantomData)
-    }
-}
+// `Mul` by a scalar conflicts with multiplying by a polynomial.
+// Use `MulAssign` or `*=` instead.

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/trivial.rs
@@ -12,7 +12,7 @@ use std::{
 use ark_ff::{One, Zero};
 use ark_poly::polynomial::univariate::{DenseOrSparsePolynomial, DensePolynomial};
 
-use crate::primitives::poly::{modular_poly::Poly, C::Coeff, PolyConf};
+use crate::primitives::poly::{modular_poly::Poly, PolyConf};
 
 impl<C: PolyConf> Borrow<DensePolynomial<C::Coeff>> for Poly<C> {
     fn borrow(&self) -> &DensePolynomial<C::Coeff> {

--- a/eyelid-match-ops/src/primitives/poly/test/gen.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/gen.rs
@@ -7,9 +7,9 @@ use crate::primitives::poly::{Poly, PolyConf};
 
 // Doc links only
 #[allow(unused_imports)]
-use crate::primitives::poly::Coeff;
+use crate::primitives::poly::C::Coeff;
 
-/// Returns an un-reduced cyclotomic polynomial of `degree`, with random coefficients in [`Coeff`].
+/// Returns an un-reduced cyclotomic polynomial of `degree`, with random coefficients in [`C::Coeff`].
 /// `degree` must be less than or equal to `C::MAX_POLY_DEGREE`.
 ///
 /// In rare cases, the degree can be less than `degree`,

--- a/eyelid-match-ops/src/primitives/poly/test/gen.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/gen.rs
@@ -5,12 +5,8 @@ use rand::Rng;
 
 use crate::primitives::poly::{Poly, PolyConf};
 
-// Doc links only
-#[allow(unused_imports)]
-use crate::primitives::poly::C::Coeff;
-
-/// Returns an un-reduced cyclotomic polynomial of `degree`, with random coefficients in [`C::Coeff`].
-/// `degree` must be less than or equal to `C::MAX_POLY_DEGREE`.
+/// Returns an un-reduced cyclotomic polynomial of `degree`, with random coefficients in [`PolyConf::Coeff`].
+/// `degree` must be less than or equal to [`PolyConf::MAX_POLY_DEGREE`].
 ///
 /// In rare cases, the degree can be less than `degree`,
 /// because the random coefficient of `X^[C::MAX_POLY_DEGREE]` is zero.

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -39,7 +39,7 @@ fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {
             Poly::one(),
             "incorrect inverse() impl: the inverse of f was y, because f * y == 1"
         );
-        // Since all non-zero `Coeff` values *are* invertible in the integer field, `f * y` can't be a constant, either.
+        // Since all non-zero `C::Coeff` values *are* invertible in the integer field, `f * y` can't be a constant, either.
         if fy != Poly::zero() {
             assert_ne!(fy.degree(), 0, "incorrect inverse() impl: the inverse of f was y*(c^1), because f * y is a non-zero constant c");
         }

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -5,7 +5,7 @@ use ark_poly::Polynomial;
 
 use crate::primitives::poly::{
     flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
-    test::gen::rand_poly, Coeff, Poly, PolyConf, TestRes,
+    test::gen::rand_poly, C::Coeff, Poly, PolyConf, TestRes,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
@@ -67,18 +67,18 @@ where
     // We can't use the standard methods, because we want an un-reduced polynomial.
     // But it is in canonical form, because the leading coefficient is non-zero.
     let mut x_max: Poly<C> = Poly::zero();
-    x_max[C::MAX_POLY_DEGREE] = Coeff::one();
+    x_max[C::MAX_POLY_DEGREE] = C::Coeff::one();
 
     // Manually calculate the reduced representation of X^N as the constant `MODULUS - 1`.
     let (q, x_max) = x_max
         .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<C>())
         .expect("is divisible by X^C::MAX_POLY_DEGREE");
 
-    assert_eq!(q, Poly::from_coefficients_vec(vec![Coeff::one()]));
+    assert_eq!(q, Poly::from_coefficients_vec(vec![C::Coeff::one()]));
     assert_eq!(
         x_max,
         // TODO: should `MODULUS - 1` be a constant?
-        Poly::from_coefficients_vec(vec![Coeff::zero() - Coeff::one()]),
+        Poly::from_coefficients_vec(vec![C::Coeff::zero() - C::Coeff::one()]),
     );
 
     for i in 0..=C::MAX_POLY_DEGREE {

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -5,7 +5,7 @@ use ark_poly::Polynomial;
 
 use crate::primitives::poly::{
     flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
-    test::gen::rand_poly, C::Coeff, Poly, PolyConf, TestRes,
+    test::gen::rand_poly, Poly, PolyConf, TestRes,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.

--- a/eyelid-match-ops/src/primitives/yashe.rs
+++ b/eyelid-match-ops/src/primitives/yashe.rs
@@ -7,7 +7,7 @@ use ark_ff::{One, UniformRand};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Normal};
 
-use crate::primitives::poly::{Coeff, Poly, PolyConf};
+use crate::primitives::poly::{C::Coeff, Poly, PolyConf};
 
 #[cfg(test)]
 pub mod test;
@@ -70,8 +70,8 @@ impl<C: PolyConf> Yashe<C> {
             };
 
             let mut priv_key = f.clone();
-            priv_key *= Coeff::from(self.params.t);
-            priv_key[0] += Coeff::one();
+            priv_key *= C::Coeff::from(self.params.t);
+            priv_key[0] += C::Coeff::one();
             priv_key.truncate_to_canonical_form();
 
             let priv_key_inv = priv_key.inverse();
@@ -90,7 +90,7 @@ impl<C: PolyConf> Yashe<C> {
     ) -> PublicKey<C> {
         let mut h = self.sample_uniform(rng);
 
-        h *= Coeff::from(self.params.t);
+        h *= C::Coeff::from(self.params.t);
         h.truncate_to_canonical_form();
         h = h * &private_key.finv;
 
@@ -118,8 +118,8 @@ impl<C: PolyConf> Yashe<C> {
             //
             // Until we've checked the security of using fewer bits, use a large and performant type.
             // Larger values are extremely rare, and will saturate to MIN or MAX.
-            // This is ok because the Coeff modulus is smaller than MIN/MAX.
-            res[i] = Coeff::from(v as i64);
+            // This is ok because the C::Coeff modulus is smaller than MIN/MAX.
+            res[i] = C::Coeff::from(v as i64);
         }
         res.truncate_to_canonical_form();
         res
@@ -129,7 +129,7 @@ impl<C: PolyConf> Yashe<C> {
     pub fn sample_uniform(&self, mut rng: &mut ThreadRng) -> Poly<C> {
         let mut res = Poly::non_canonical_zeroes(C::MAX_POLY_DEGREE);
         for i in 0..C::MAX_POLY_DEGREE {
-            let coeff_rand = Coeff::rand(&mut rng);
+            let coeff_rand = C::Coeff::rand(&mut rng);
             res[i] = coeff_rand;
         }
         res.truncate_to_canonical_form();

--- a/eyelid-match-ops/src/primitives/yashe.rs
+++ b/eyelid-match-ops/src/primitives/yashe.rs
@@ -23,7 +23,10 @@ pub struct YasheParams {
 
 /// Yashe scheme
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Yashe<C: PolyConf> {
+pub struct Yashe<C: PolyConf>
+where
+    C::Coeff: From<i64> + From<u64>,
+{
     /// Cryptosystem parameters
     /// TODO: turn these into a trait and marker type, with a `PolyConf` type in the cryptosystem trait
     params: YasheParams,
@@ -50,7 +53,10 @@ pub struct PublicKey<C: PolyConf> {
     pub h: Poly<C>,
 }
 
-impl<C: PolyConf> Yashe<C> {
+impl<C: PolyConf> Yashe<C>
+where
+    C::Coeff: From<i64> + From<u64>,
+{
     /// Yashe constructor
     pub fn new(params: YasheParams) -> Self {
         Self {

--- a/eyelid-match-ops/src/primitives/yashe.rs
+++ b/eyelid-match-ops/src/primitives/yashe.rs
@@ -7,7 +7,7 @@ use ark_ff::{One, UniformRand};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Normal};
 
-use crate::primitives::poly::{C::Coeff, Poly, PolyConf};
+use crate::primitives::poly::{Poly, PolyConf};
 
 #[cfg(test)]
 pub mod test;

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -2,7 +2,7 @@
 
 use crate::primitives::{
     poly::TestRes,
-    yashe::{Coeff, Poly, PolyConf, Yashe, YasheParams},
+    yashe::{C::Coeff, Poly, PolyConf, Yashe, YasheParams},
 };
 use ark_ff::One;
 use ark_poly::Polynomial;
@@ -24,7 +24,7 @@ fn keygen_helper<C: PolyConf>() {
 
     //dbg!(private_key.priv_key[0].clone());
     assert_eq!(
-        private_key.f[0] * Coeff::from(params.t) + Coeff::one(),
+        private_key.f[0] * C::Coeff::from(params.t) + C::Coeff::one(),
         private_key.priv_key[0]
     );
 

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -2,7 +2,7 @@
 
 use crate::primitives::{
     poly::TestRes,
-    yashe::{C::Coeff, Poly, PolyConf, Yashe, YasheParams},
+    yashe::{Poly, PolyConf, Yashe, YasheParams},
 };
 use ark_ff::One;
 use ark_poly::Polynomial;

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -8,7 +8,10 @@ use ark_ff::One;
 use ark_poly::Polynomial;
 
 /// Auxiliary function for testing key generation
-fn keygen_helper<C: PolyConf>() {
+fn keygen_helper<C: PolyConf>()
+where
+    C::Coeff: From<i64> + From<u64>,
+{
     // TODO: how to deal with different sets of parameters?
     // We must be able to test all the different parameterizations
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
This PR makes a lot of search-and-replace code changes, so it will cause merge conflicts. Let's merge it soon.

It changes `Coeff` from a type to an associated type of the `PolyConf` trait. As part of that change, the static zero constant becomes a trait function that returns a reference to that constant. YASHE also needs some specific conversions, they are added as trait bounds.