### PR TITLE
Clean up dependencies and make benchmark names shorter

### DIFF
--- a/.github/workflows/ci-bench-changes.yml
+++ b/.github/workflows/ci-bench-changes.yml
@@ -52,7 +52,7 @@ jobs:
        run: |
          export RUSTFLAGS="-D warnings"
          echo "Warning: benchmark timings are unreliable in CI due to virtualization"
-         cargo bench --features benchmark -- 'match|multiplication|inv|keygen' --output-format bencher | tee output.txt
+         cargo bench --features benchmark -- 'match|mul|inv|keygen' --output-format bencher | tee output.txt
          echo "Warning: benchmark timings are unreliable in CI due to virtualization"
 
      # Download previous benchmark result from the most recent `main` branch cache (if any exists).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bitvec = "1.0.1"
 # Automatically deriving trivial impls
 # Full list at <https://github.com/JelteF/derive_more/blob/v0.99.17/Cargo.toml#L42>
 # When we upgrade to 1.0.0, it will be at <https://github.com/JelteF/derive_more/blob/master/Cargo.toml#L49>
-derive_more = { version = "0.99.17", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "into", "mul", "mul_assign", "not"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "deref", "deref_mut", "into", "mul"] }
 
 # Static constants
 lazy_static = "1.4.0"

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -1,4 +1,7 @@
 //! Benchmarks for matching operations.
+//!
+//! To add a benchmark to the PR comparison, change the benchmark selection regex in
+//! `ci-bench-changes.yml`(https://github.com/Inversed-Tech/eyelid/blob/3668934d68780513ea61ede8f4ccfb2d6a7eaedb/.github/workflows/ci-bench-changes.yml#L55).
 
 #![cfg(feature = "benchmark")]
 // Allow missing docs in macro-produced code.
@@ -110,6 +113,15 @@ criterion_main!(
     bench_key_generation_iris
 );
 
+/// The name used for slow benchmark groups.
+pub const SLOW_BENCH_NAME: &str = "Slow";
+
+/// The name used for randomly generated bits.
+pub const RANDOM_BITS_NAME: &str = "random";
+
+/// The name used for small randomly distributions.
+pub const SMALL_RANDOM_NAME: &str = "small rand";
+
 /// Run [`plaintext::is_iris_match()`] as a Criterion benchmark with random data.
 fn bench_plaintext_full_match(settings: &mut Criterion) {
     // Setup: generate different random iris codes and masks
@@ -119,7 +131,7 @@ fn bench_plaintext_full_match(settings: &mut Criterion) {
     let mask_store = random_iris_mask();
 
     settings.bench_with_input(
-        BenchmarkId::new("Full iris match: plaintext", "Random bits"),
+        BenchmarkId::new("Plaintext full match", RANDOM_BITS_NAME),
         &(eye_new, mask_new, eye_store, mask_store),
         |benchmark, (eye_new, mask_new, eye_store, mask_store)| {
             benchmark.iter_with_large_drop(|| {
@@ -137,10 +149,7 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
     let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Cyclotomic multiplication: polynomial",
-            "2 random polys of degree N",
-        ),
+        BenchmarkId::new("Naive mul poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -153,7 +162,7 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
     // We can override the configuration on a per-group level
     settings.sampling_mode(Flat);
 
@@ -162,10 +171,7 @@ pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
     let p2: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Cyclotomic multiplication: polynomial",
-            "2 random polys of degree IRIS_BIT_LENGTH",
-        ),
+        BenchmarkId::new("Naive mul full poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -182,10 +188,7 @@ pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
     let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Recursive Karatsuba multiplication: polynomial",
-            "2 random polys of degree N",
-        ),
+        BenchmarkId::new("Rec karatsuba mul poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -197,7 +200,7 @@ pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
 /// Run [`poly::rec_karatsuba_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
     // We can override the configuration on a per-group level
     settings.sampling_mode(Flat);
 
@@ -206,10 +209,7 @@ pub fn bench_rec_karatsuba_mul_iris(settings: &mut Criterion) {
     let p2: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Recursive Karatsuba multiplication: polynomial",
-            "2 random polys of degree IRIS_BIT_LENGTH",
-        ),
+        BenchmarkId::new("Rec karatsuba mul full poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -225,10 +225,7 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
     let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Flat Karatsuba multiplication: polynomial",
-            "2 random polys of degree N",
-        ),
+        BenchmarkId::new("Flat karatsuba mul poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -240,7 +237,7 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
 /// Run [`poly::flat_karatsuba_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
     // We can override the configuration on a per-group level
     settings.sampling_mode(Flat);
 
@@ -249,10 +246,7 @@ pub fn bench_flat_karatsuba_mul_iris(settings: &mut Criterion) {
     let p2: Poly<IrisBits> = rand_poly(IrisBits::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Flat Karatsuba multiplication: polynomial",
-            "2 random polys of degree IRIS_BIT_LENGTH",
-        ),
+        BenchmarkId::new("Flat karatsuba mul full poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -268,7 +262,7 @@ pub fn bench_poly_split_half(settings: &mut Criterion) {
     let p: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new("Karatsuba: poly split half", "random poly of degree N"),
+        BenchmarkId::new("Split poly half", RANDOM_BITS_NAME),
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -285,7 +279,7 @@ pub fn bench_poly_split_2(settings: &mut Criterion) {
     let p: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new("Karatsuba: poly split 2", "random poly of degree N"),
+        BenchmarkId::new("Split poly 2", RANDOM_BITS_NAME),
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -300,7 +294,7 @@ pub fn bench_mod_poly_manual(settings: &mut Criterion) {
     let dividend: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE * 2);
 
     settings.bench_with_input(
-        BenchmarkId::new("Manual polynomial modulus", "A random poly of degree 2N"),
+        BenchmarkId::new("Manual mod reduce poly", RANDOM_BITS_NAME),
         &dividend,
         |benchmark, dividend| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -323,7 +317,7 @@ pub fn bench_mod_poly_ark(settings: &mut Criterion) {
     let dividend: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE * 2);
 
     settings.bench_with_input(
-        BenchmarkId::new("ark-poly polynomial modulus", "A random poly of degree 2N"),
+        BenchmarkId::new("ark-ff mod reduce poly", RANDOM_BITS_NAME),
         &dividend,
         |benchmark, dividend| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -346,10 +340,7 @@ pub fn bench_inv(settings: &mut Criterion) {
     let p = ctx.sample_gaussian(&mut rng);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Cyclotomic inverse: polynomial",
-            "1 relatively small random poly of degree N",
-        ),
+        BenchmarkId::new("Inverse poly", SMALL_RANDOM_NAME),
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -362,7 +353,7 @@ pub fn bench_inv(settings: &mut Criterion) {
 /// Run [`poly::inverse()`] as a Criterion benchmark with gaussian random data on the full number of iris bits.
 pub fn bench_inv_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
     // We can override the configuration on a per-group level
     settings.sampling_mode(Flat);
 
@@ -375,10 +366,7 @@ pub fn bench_inv_iris(settings: &mut Criterion) {
     let p = ctx.sample_gaussian(&mut rng);
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "Cyclotomic inverse: polynomial",
-            "1 relatively small random poly of degree IRIS_BIT_LENGTH",
-        ),
+        BenchmarkId::new("Inverse full poly", SMALL_RANDOM_NAME),
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -394,7 +382,7 @@ pub fn bench_keygen(settings: &mut Criterion) {
     let ctx: Yashe<TestRes> = Yashe::new();
 
     settings.bench_with_input(
-        BenchmarkId::new("YASHE keygen", "standard parameters with degree N"),
+        BenchmarkId::new("YASHE keygen", SMALL_RANDOM_NAME),
         &ctx,
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -412,7 +400,7 @@ pub fn bench_keygen(settings: &mut Criterion) {
 /// Run [`Yashe::keygen()`] as a Criterion benchmark with random data on the full number of iris bits.
 pub fn bench_keygen_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group("Slow Benchmarks");
+    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
     // We can override the configuration on a per-group level
     settings.sampling_mode(Flat);
 
@@ -420,10 +408,7 @@ pub fn bench_keygen_iris(settings: &mut Criterion) {
     let ctx: Yashe<IrisBits> = Yashe::new();
 
     settings.bench_with_input(
-        BenchmarkId::new(
-            "YASHE keygen",
-            "standard parameters with degree IRIS_BIT_LENGTH",
-        ),
+        BenchmarkId::new("YASHE full keygen", SMALL_RANDOM_NAME),
         &ctx,
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -2,6 +2,12 @@
 //!
 //! To add a benchmark to the PR comparison, change the benchmark selection regex in
 //! `ci-bench-changes.yml`(https://github.com/Inversed-Tech/eyelid/blob/3668934d68780513ea61ede8f4ccfb2d6a7eaedb/.github/workflows/ci-bench-changes.yml#L55).
+//!
+//! Benchmarks that take longer than a minute are disabled by default.
+//! Use this command to run the benchmarks that are very slow:
+//! ```sh
+//! RUSTFLAGS="--cfg slow_benchmarks" cargo bench --features benchmark
+//! ```
 
 #![cfg(feature = "benchmark")]
 // Allow missing docs in macro-produced code.
@@ -76,14 +82,25 @@ criterion_group! {
 // Iris-length polynomial benchmarks.
 // These benchmarks provide an upper bound for the performance of iris operations.
 // They also help us decide if we need smaller or larger polynomial sizes.
+#[cfg(not(slow_benchmarks))]
 criterion_group! {
     name = bench_cyclotomic_multiplication_iris;
     // This can be any expression that returns a `Criterion` object.
-    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(40));
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(50));
+    // List iris-length polynomial multiplication implementations here.
+    targets = bench_rec_karatsuba_mul_iris, bench_flat_karatsuba_mul_iris
+}
+
+#[cfg(slow_benchmarks)]
+criterion_group! {
+    name = bench_cyclotomic_multiplication_iris;
+    // This can be any expression that returns a `Criterion` object.
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(50));
     // List iris-length polynomial multiplication implementations here.
     targets = bench_naive_cyclotomic_mul_iris, bench_rec_karatsuba_mul_iris, bench_flat_karatsuba_mul_iris
 }
 
+#[cfg(slow_benchmarks)]
 criterion_group! {
     name = bench_inverse_iris;
     // This can be any expression that returns a `Criterion` object.
@@ -92,6 +109,7 @@ criterion_group! {
     targets = bench_inv_iris
 }
 
+#[cfg(slow_benchmarks)]
 criterion_group! {
     name = bench_key_generation_iris;
     // This can be any expression that returns a `Criterion` object.
@@ -101,6 +119,18 @@ criterion_group! {
 }
 
 // List groups here.
+#[cfg(not(slow_benchmarks))]
+criterion_main!(
+    bench_full_match,
+    bench_cyclotomic_multiplication,
+    bench_poly_split_karatsuba,
+    bench_polynomial_modulus,
+    bench_inverse,
+    bench_key_generation,
+    bench_cyclotomic_multiplication_iris,
+);
+
+#[cfg(slow_benchmarks)]
 criterion_main!(
     bench_full_match,
     bench_cyclotomic_multiplication,
@@ -160,6 +190,7 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
 }
 
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data on the full number of iris bits.
+#[cfg(slow_benchmarks)]
 pub fn bench_naive_cyclotomic_mul_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
     let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
@@ -351,6 +382,7 @@ pub fn bench_inv(settings: &mut Criterion) {
 }
 
 /// Run [`poly::inverse()`] as a Criterion benchmark with gaussian random data on the full number of iris bits.
+#[cfg(slow_benchmarks)]
 pub fn bench_inv_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
     let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
@@ -398,6 +430,7 @@ pub fn bench_keygen(settings: &mut Criterion) {
 }
 
 /// Run [`Yashe::keygen()`] as a Criterion benchmark with random data on the full number of iris bits.
+#[cfg(slow_benchmarks)]
 pub fn bench_keygen_iris(settings: &mut Criterion) {
     // Tweak configuration for a long-running test
     let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);

--- a/eyelid-match-ops/src/primitives/poly/modular_poly.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly.rs
@@ -33,14 +33,21 @@ pub(super) mod mul;
 mod trivial;
 
 /// A modular polynomial with coefficients in [`PolyConf::Coeff`], and a generic maximum degree
-/// [`PolyConf::MAX_POLY_DEGREE`]. The un-reduced polynomial modulus is the polynomial modulus. TODO
+/// [`PolyConf::MAX_POLY_DEGREE`]. The polynomial modulus is `X^MAX_POLY_DEGREE + 1`. Polynomials
+/// are always in their canonical, modular reduced form.
 ///
-/// In its canonical form, a polynomial is a list of coefficients from the constant term `X^0`
-/// to the degree `X^n`, where the highest coefficient is non-zero. Leading zero coefficients are
-/// not stored.
+/// In this canonical form, a polynomial is a list of coefficients from the constant term `X^0`
+/// to `X^{MAX_POLY_DEGREE - 1}`, where the highest coefficient is non-zero.
 ///
-/// There is one more coefficient than the degree, because of the constant term. If the polynomial
-/// is the zero polynomial, the degree is `0`, and there are no coefficients.
+/// This canonical form is stored and maintained as follows:
+/// - The coefficient of `X^i` is stored at `self[i]`.
+/// - `X^MAX_POLY_DEGREE` is reduced to `PolyConf::Coeff::MODULUS - 1`.
+/// - Leading zero coefficients are not stored.
+/// - If the polynomial is the zero polynomial, the degree is `0`, and there are no coefficients.
+///
+/// Every operation which can change the degree must call [`Poly::reduce_mod_poly()`].
+/// If an operation can create leading zero coefficients, but will never increase the degree, it can call
+/// [`Poly::truncate_to_canonical_form()`] instead.
 #[derive(
     Clone,
     Debug,


### PR DESCRIPTION
This PR makes 4 minor cleanups:
- expand `Poly` docs to explain the canonical form
- remove unused dependency features
- make benchmark names shorter to make benchmark comments clearer
- disable some very slow benchmarks by default (1 minute or more)

This is how long each benchmark takes:
https://github.com/Inversed-Tech/eyelid/actions/runs/9009060543/job/24752511648#step:5:31