### PR TITLE
Add an IrisConf trait, but don't convert function code to it yet

### DIFF
--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -24,9 +24,10 @@ use eyelid_match_ops::{
         test::gen::{random_iris_code, random_iris_mask},
     },
     primitives::{
-        poly::{self, test::gen::rand_poly, IrisBits, Poly, PolyConf, TestRes},
+        poly::{self, test::gen::rand_poly, Poly, PolyConf},
         yashe::{self, Yashe},
     },
+    IrisBits, TestRes,
 };
 
 // Configure Criterion:

--- a/eyelid-match-ops/src/conf.rs
+++ b/eyelid-match-ops/src/conf.rs
@@ -1,0 +1,38 @@
+//! Configuration marker types.
+//! Any or all of the configuration traits can be implemented on these types, or your own custom
+//! types.
+
+/// The polynomial config used in tests.
+//
+// We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
+#[cfg(not(tiny_poly))]
+pub type TestRes = FullRes;
+
+/// The polynomial config used in tests.
+///
+/// Temporarily switch to this tiny field to make test errors easier to debug:
+/// ```no_run
+/// RUSTFLAGS="--cfg tiny_poly" cargo test
+/// RUSTFLAGS="--cfg tiny_poly" cargo bench --features benchmark
+/// ```
+#[cfg(tiny_poly)]
+pub type TestRes = TinyTest;
+
+/// Iris bit length polynomial parameters.
+///
+/// This uses the full number of iris bits, which gives an upper bound on benchmarks.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct IrisBits;
+
+/// Full resolution polynomial parameters.
+///
+/// These are the parameters for full resolution, according to the Inversed Tech report.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FullRes;
+
+/// Tiny test polynomials, used for finding edge cases in tests.
+///
+/// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
+#[cfg(tiny_poly)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TinyTest;

--- a/eyelid-match-ops/src/encoded.rs
+++ b/eyelid-match-ops/src/encoded.rs
@@ -1,11 +1,16 @@
 //! Iris matching operations on polynomial-encoded bit vectors.
 
-use itertools::Itertools;
 use std::error::Error;
 
-use crate::plaintext::{index_1d, IrisCode, IrisMask};
-use crate::primitives::poly::modular_poly::conf::FullRes;
-use crate::primitives::poly::{Poly, PolyConf};
+use ark_ff::{One, Zero};
+use itertools::Itertools;
+use num_bigint::BigUint;
+
+use crate::{
+    plaintext::{index_1d, IrisCode, IrisMask},
+    primitives::poly::{Poly, PolyConf},
+    FullRes,
+};
 use crate::{
     IRIS_BIT_LENGTH,
     IRIS_COLUMNS as NUM_COLS, // The number of columns of the code: `k`
@@ -15,8 +20,6 @@ use crate::{
     IRIS_ROTATION_COMPARISONS as NUM_ROTATIONS, // The number of rotations: `v - u + 1`
     IRIS_ROTATION_LIMIT,                        // The rotation limits: `v` and `u = -v`
 };
-use ark_ff::{One, Zero};
-use num_bigint::BigUint;
 
 #[cfg(any(test, feature = "benchmark"))]
 pub mod test;

--- a/eyelid-match-ops/src/iris.rs
+++ b/eyelid-match-ops/src/iris.rs
@@ -1,0 +1,3 @@
+//! Scheme-independent iris code and configurations.
+
+pub mod conf;

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -38,11 +38,14 @@ impl IrisConf for IrisBits {
     const COLUMNS: usize = 160;
     const ROTATION_LIMIT: usize = 15;
 }
+// TODO: work out how to automatically apply these assertions to every trait impl.
+// (Or every config type.)
+//
 // There must be enough bits to store the underlying data.
 const_assert!(IrisBits::BIT_LENGTH >= IrisBits::COLUMN_LENGTH * IrisBits::COLUMNS);
 // Rotating more than the number of columns is redundant.
 const_assert!(IrisBits::ROTATION_COMPARISONS <= IrisBits::COLUMNS);
-// The match fraction should be strictly between 0 and 1.
+// The match fraction should be between 0 and 1.
 const_assert!(IrisBits::MATCH_NUMERATOR <= IrisBits::MATCH_DENOMINATOR);
 const_assert!(IrisBits::MATCH_DENOMINATOR > 0);
 

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -1,4 +1,4 @@
-//! Iris configurations for encoding and encrption schemes.
+//! Iris configurations for encoding and encryption schemes.
 
 use crate::{FullRes, IrisBits};
 
@@ -64,6 +64,8 @@ impl IrisConf for TinyTest {
 }
 #[cfg(tiny_poly)]
 mod tiny_test_asserts {
+    use super::*;
+
     const_assert!(TinyTest::BIT_LENGTH >= TinyTest::COLUMN_LENGTH * TinyTest::COLUMNS);
     const_assert!(TinyTest::ROTATION_COMPARISONS <= TinyTest::COLUMNS);
     const_assert!(TinyTest::MATCH_NUMERATOR <= TinyTest::MATCH_DENOMINATOR);

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -1,5 +1,10 @@
 //! Iris configurations for encoding and encrption schemes.
 
+use crate::{FullRes, IrisBits};
+
+#[cfg(tiny_poly)]
+use crate::TinyTest;
+
 /// The dimensions and matching rules for an iris code.
 pub trait IrisConf {
     /// The number of rows in an iris code or iris mask.
@@ -26,4 +31,41 @@ pub trait IrisConf {
     /// The denominator of the bit match threshold for a successful iris match.
     /// The default match threshold is 36%.
     const MATCH_DENOMINATOR: usize = 100;
+}
+
+impl IrisConf for IrisBits {
+    const COLUMN_LENGTH: usize = 80;
+    const COLUMNS: usize = 160;
+    const ROTATION_LIMIT: usize = 15;
+}
+// There must be enough bits to store the underlying data.
+const_assert!(IrisBits::BIT_LENGTH >= IrisBits::COLUMN_LENGTH * IrisBits::COLUMNS);
+// Rotating more than the number of columns is redundant.
+const_assert!(IrisBits::ROTATION_COMPARISONS <= IrisBits::COLUMNS);
+// The match fraction should be strictly between 0 and 1.
+const_assert!(IrisBits::MATCH_NUMERATOR <= IrisBits::MATCH_DENOMINATOR);
+const_assert!(IrisBits::MATCH_DENOMINATOR > 0);
+
+impl IrisConf for FullRes {
+    const COLUMN_LENGTH: usize = 10;
+    const COLUMNS: usize = 160;
+    const ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
+}
+const_assert!(FullRes::BIT_LENGTH >= FullRes::COLUMN_LENGTH * FullRes::COLUMNS);
+const_assert!(FullRes::ROTATION_COMPARISONS <= FullRes::COLUMNS);
+const_assert!(FullRes::MATCH_NUMERATOR <= FullRes::MATCH_DENOMINATOR);
+const_assert!(FullRes::MATCH_DENOMINATOR > 0);
+
+#[cfg(tiny_poly)]
+impl IrisConf for TinyTest {
+    const COLUMN_LENGTH: usize = 2;
+    const COLUMNS: usize = 3;
+    const ROTATION_LIMIT: usize = 1;
+}
+#[cfg(tiny_poly)]
+mod tiny_test_asserts {
+    const_assert!(TinyTest::BIT_LENGTH >= TinyTest::COLUMN_LENGTH * TinyTest::COLUMNS);
+    const_assert!(TinyTest::ROTATION_COMPARISONS <= TinyTest::COLUMNS);
+    const_assert!(TinyTest::MATCH_NUMERATOR <= TinyTest::MATCH_DENOMINATOR);
+    const_assert!(TinyTest::MATCH_DENOMINATOR > 0);
 }

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -1,0 +1,29 @@
+//! Iris configurations for encoding and encrption schemes.
+
+/// The dimensions and matching rules for an iris code.
+pub trait IrisConf {
+    /// The number of rows in an iris code or iris mask.
+    const COLUMN_LENGTH: usize;
+
+    /// The number of columns in an iris code or iris mask.
+    const COLUMNS: usize;
+
+    /// The length of an iris code or iris mask.
+    const BIT_LENGTH: usize = Self::COLUMN_LENGTH * Self::COLUMNS;
+
+    /// The rotation limit when comparing irises.
+    /// Each column is compared to the [`ROTATION_LIMIT`](Self::ROTATION_LIMIT) columns to its left and right.
+    const ROTATION_LIMIT: usize;
+
+    /// The number of rotations used when comparing irises.
+    /// This includes the comparison with no rotation.
+    const ROTATION_COMPARISONS: usize = Self::ROTATION_LIMIT * 2 + 1;
+
+    /// The numerator of the bit match threshold for a successful iris match.
+    /// The default match threshold is 36%.
+    const MATCH_NUMERATOR: usize = 36;
+
+    /// The denominator of the bit match threshold for a successful iris match.
+    /// The default match threshold is 36%.
+    const MATCH_DENOMINATOR: usize = 100;
+}

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -62,6 +62,8 @@ impl IrisConf for TinyTest {
     const COLUMNS: usize = 3;
     const ROTATION_LIMIT: usize = 1;
 }
+
+/// This module avoids repeating `#[cfg(tiny_poly)]` for each assertion.
 #[cfg(tiny_poly)]
 mod tiny_test_asserts {
     use super::*;

--- a/eyelid-match-ops/src/lib.rs
+++ b/eyelid-match-ops/src/lib.rs
@@ -28,26 +28,29 @@ pub use conf::TestRes;
 #[cfg(tiny_poly)]
 pub use conf::TinyTest;
 
+// TODO: delete these constants after the crate has been updated to use IrisConf generic parameters.
+use iris::conf::IrisConf;
+
 /// The number of rows in a raw iris code or iris mask, in bits.
-pub const IRIS_COLUMN_LENGTH: usize = 80;
+pub const IRIS_COLUMN_LENGTH: usize = IrisBits::COLUMN_LENGTH;
 
 /// The number of columns in a raw iris code or iris mask, in bits.
-pub const IRIS_COLUMNS: usize = 160;
+pub const IRIS_COLUMNS: usize = IrisBits::COLUMNS;
 
 /// The length of a raw iris code or iris mask, in bits.
 /// Most users have two of these codes, for their left and right eyes.
-pub const IRIS_BIT_LENGTH: usize = IRIS_COLUMN_LENGTH * IRIS_COLUMNS;
+pub const IRIS_BIT_LENGTH: usize = IrisBits::BIT_LENGTH;
 
 /// The rotation limit when comparing irises.
 /// Each column is compared to the [`IRIS_ROTATION_LIMIT`] columns to its left and right.
-pub const IRIS_ROTATION_LIMIT: usize = 15;
+pub const IRIS_ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
 
 /// The number of rotations used when comparing irises.
 /// This includes the comparison with no rotations.
-pub const IRIS_ROTATION_COMPARISONS: usize = IRIS_ROTATION_LIMIT * 2 + 1;
+pub const IRIS_ROTATION_COMPARISONS: usize = IrisBits::ROTATION_COMPARISONS;
 
 /// The numerator of the bit match threshold for a successful iris match.
-pub const IRIS_MATCH_NUMERATOR: usize = 36;
+pub const IRIS_MATCH_NUMERATOR: usize = IrisBits::MATCH_NUMERATOR;
 
 /// The denominator of the bit match threshold for a successful iris match.
-pub const IRIS_MATCH_DENOMINATOR: usize = 100;
+pub const IRIS_MATCH_DENOMINATOR: usize = IrisBits::MATCH_DENOMINATOR;

--- a/eyelid-match-ops/src/lib.rs
+++ b/eyelid-match-ops/src/lib.rs
@@ -46,15 +46,8 @@ pub const IRIS_ROTATION_LIMIT: usize = 15;
 /// This includes the comparison with no rotations.
 pub const IRIS_ROTATION_COMPARISONS: usize = IRIS_ROTATION_LIMIT * 2 + 1;
 
-// Rotating more than the number of columns is redundant.
-const_assert!(IRIS_ROTATION_COMPARISONS <= IRIS_COLUMNS);
-
 /// The numerator of the bit match threshold for a successful iris match.
 pub const IRIS_MATCH_NUMERATOR: usize = 36;
 
 /// The denominator of the bit match threshold for a successful iris match.
 pub const IRIS_MATCH_DENOMINATOR: usize = 100;
-
-// The match fraction should be strictly between 0 and 1.
-const_assert!(IRIS_MATCH_NUMERATOR < IRIS_MATCH_DENOMINATOR);
-const_assert!(IRIS_MATCH_NUMERATOR > 0);

--- a/eyelid-match-ops/src/lib.rs
+++ b/eyelid-match-ops/src/lib.rs
@@ -13,11 +13,20 @@
 #[macro_use]
 extern crate static_assertions;
 
+pub mod conf;
 pub mod encoded;
 pub mod encrypted;
 pub mod iris;
 pub mod plaintext;
 pub mod primitives;
+
+pub use conf::{FullRes, IrisBits};
+
+#[cfg(any(test, feature = "benchmark"))]
+pub use conf::TestRes;
+
+#[cfg(tiny_poly)]
+pub use conf::TinyTest;
 
 /// The number of rows in a raw iris code or iris mask, in bits.
 pub const IRIS_COLUMN_LENGTH: usize = 80;

--- a/eyelid-match-ops/src/lib.rs
+++ b/eyelid-match-ops/src/lib.rs
@@ -15,6 +15,7 @@ extern crate static_assertions;
 
 pub mod encoded;
 pub mod encrypted;
+pub mod iris;
 pub mod plaintext;
 pub mod primitives;
 

--- a/eyelid-match-ops/src/primitives/poly.rs
+++ b/eyelid-match-ops/src/primitives/poly.rs
@@ -12,8 +12,6 @@ pub use modular_poly::{
 };
 
 // Only for tests.
-#[cfg(any(test, feature = "benchmark"))]
-pub use modular_poly::conf::{IrisBits, TestRes};
 
 // Use `mod_poly` outside this module, it is set to the fastest modulus operation.
 #[cfg(any(test, feature = "benchmark"))]

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use ark_ff::{PrimeField, Zero};
 use lazy_static::lazy_static;
 
-use crate::{primitives::poly::Fq79, FullRes, IrisBits};
+use crate::{iris::conf::IrisConf, primitives::poly::Fq79, FullRes, IrisBits};
 
 #[cfg(tiny_poly)]
 use crate::{primitives::poly::fq::FqTiny, TinyTest};
@@ -36,7 +36,7 @@ pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
 }
 
 impl PolyConf for IrisBits {
-    const MAX_POLY_DEGREE: usize = crate::IRIS_BIT_LENGTH;
+    const MAX_POLY_DEGREE: usize = Self::BIT_LENGTH;
 
     type Coeff = Fq79;
 
@@ -44,6 +44,8 @@ impl PolyConf for IrisBits {
         &FQ79_ZERO
     }
 }
+// The polynomial must have enough coefficients to store the underlying iris data.
+const_assert!(IrisBits::MAX_POLY_DEGREE >= IrisBits::BIT_LENGTH);
 
 lazy_static! {
     /// The zero coefficient as a static constant value.
@@ -62,6 +64,7 @@ impl PolyConf for FullRes {
         &FQ79_ZERO
     }
 }
+const_assert!(FullRes::MAX_POLY_DEGREE >= FullRes::BIT_LENGTH);
 
 #[cfg(tiny_poly)]
 impl PolyConf for TinyTest {
@@ -73,6 +76,9 @@ impl PolyConf for TinyTest {
         &FQ_TINY_ZERO
     }
 }
+
+#[cfg(tiny_poly)]
+const_assert!(TinyTest::MAX_POLY_DEGREE >= TinyTest::BIT_LENGTH);
 
 #[cfg(tiny_poly)]
 lazy_static! {

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -5,26 +5,10 @@ use std::fmt::Debug;
 use ark_ff::{PrimeField, Zero};
 use lazy_static::lazy_static;
 
-use crate::primitives::poly::Fq79;
+use crate::{primitives::poly::Fq79, FullRes, IrisBits};
 
 #[cfg(tiny_poly)]
-use crate::primitives::poly::fq::FqTiny;
-
-/// The polynomial config used in tests.
-//
-// We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
-#[cfg(not(tiny_poly))]
-pub type TestRes = FullRes;
-
-/// The polynomial config used in tests.
-///
-/// Temporarily switch to this tiny field to make test errors easier to debug:
-/// ```no_run
-/// RUSTFLAGS="--cfg tiny_poly" cargo test
-/// RUSTFLAGS="--cfg tiny_poly" cargo bench --features benchmark
-/// ```
-#[cfg(tiny_poly)]
-pub type TestRes = TinyTest;
+use crate::{primitives::poly::fq::FqTiny, TinyTest};
 
 /// Fixed polynomial parameters.
 ///
@@ -51,12 +35,6 @@ pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
     fn coeff_zero() -> &'static Self::Coeff;
 }
 
-/// Iris bit length polynomial parameters.
-///
-/// This uses the full number of iris bits, which gives an upper bound on benchmarks.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct IrisBits;
-
 impl PolyConf for IrisBits {
     const MAX_POLY_DEGREE: usize = crate::IRIS_BIT_LENGTH;
 
@@ -75,14 +53,6 @@ lazy_static! {
 // TODO: try generic_singleton and see if it performs better:
 // <https://docs.rs/generic_singleton/0.5.0/generic_singleton/macro.get_or_init_thread_local.html>
 
-/// Full resolution polynomial parameters.
-///
-/// These are the parameters for full resolution, according to the Inversed Tech report.
-#[cfg(not(tiny_poly))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct FullRes;
-
-#[cfg(not(tiny_poly))]
 impl PolyConf for FullRes {
     const MAX_POLY_DEGREE: usize = 2048;
 
@@ -92,13 +62,6 @@ impl PolyConf for FullRes {
         &FQ79_ZERO
     }
 }
-
-/// Tiny test polynomials, used for finding edge cases in tests.
-///
-/// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
-#[cfg(tiny_poly)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct TinyTest;
 
 #[cfg(tiny_poly)]
 impl PolyConf for TinyTest {

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -46,6 +46,8 @@ impl PolyConf for IrisBits {
 }
 // The polynomial must have enough coefficients to store the underlying iris data.
 const_assert!(IrisBits::MAX_POLY_DEGREE >= IrisBits::BIT_LENGTH);
+// The degree must be a power of two.
+const_assert!(IrisBits::MAX_POLY_DEGREE.count_ones() == 1);
 
 // TODO: try generic_singleton and see if it performs better:
 // <https://docs.rs/generic_singleton/0.5.0/generic_singleton/macro.get_or_init_thread_local.html>
@@ -64,6 +66,7 @@ impl PolyConf for FullRes {
     }
 }
 const_assert!(FullRes::MAX_POLY_DEGREE >= FullRes::BIT_LENGTH);
+const_assert!(FullRes::MAX_POLY_DEGREE.count_ones() == 1);
 
 #[cfg(tiny_poly)]
 impl PolyConf for TinyTest {
@@ -76,8 +79,13 @@ impl PolyConf for TinyTest {
     }
 }
 
+/// This module avoids repeating `#[cfg(tiny_poly)]` for each assertion.
 #[cfg(tiny_poly)]
-const_assert!(TinyTest::MAX_POLY_DEGREE >= TinyTest::BIT_LENGTH);
+mod tiny_test_asserts {
+    use super::*;
+    const_assert!(TinyTest::MAX_POLY_DEGREE >= TinyTest::BIT_LENGTH);
+    const_assert!(TinyTest::MAX_POLY_DEGREE.count_ones() == 1);
+}
 
 #[cfg(tiny_poly)]
 lazy_static! {

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/modulus.rs
@@ -74,7 +74,8 @@ pub fn mod_poly_ark_mut<C: PolyConf>(dividend: &mut Poly<C>) {
 /// This is the canonical but un-reduced form of the modulus, because the reduced form is the zero polynomial.
 ///
 /// TODO: work out how to generically make this a lazy static.
-/// Crates like `interned` or `lazy_static` might help, but we'll have to expand their macros and make them generic.
+/// Crates like `interned`, `lazy_static`, or `generic_singleton` might help:
+// <https://docs.rs/generic_singleton/0.5.0/generic_singleton/macro.get_or_init_thread_local.html>
 pub fn new_unreduced_poly_modulus_slow<C: PolyConf>() -> Poly<C> {
     let mut poly = Poly::zero();
 

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,18 +1,19 @@
 //! Tests for polynomial inverse.
 
 use ark_ff::{One, Zero};
-
-use crate::primitives::{
-    poly::{
-        modular_poly::inv::{extended_gcd, inverse},
-        test::gen::rand_poly,
-        Poly, PolyConf, TestRes,
-    },
-    yashe::Yashe,
-};
-
-#[cfg(test)]
 use ark_poly::Polynomial;
+
+use crate::{
+    primitives::{
+        poly::{
+            modular_poly::inv::{extended_gcd, inverse},
+            test::gen::rand_poly,
+            Poly, PolyConf,
+        },
+        yashe::Yashe,
+    },
+    TestRes,
+};
 
 fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {
     // REMARK: For our parameter choices it is very likely to find

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -3,9 +3,12 @@
 use ark_ff::{One, Zero};
 use ark_poly::Polynomial;
 
-use crate::primitives::poly::{
-    flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow, rec_karatsuba_mul,
-    test::gen::rand_poly, Poly, PolyConf, TestRes,
+use crate::{
+    primitives::poly::{
+        flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow,
+        rec_karatsuba_mul, test::gen::rand_poly, Poly, PolyConf,
+    },
+    TestRes,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.

--- a/eyelid-match-ops/src/primitives/yashe/conf.rs
+++ b/eyelid-match-ops/src/primitives/yashe/conf.rs
@@ -67,7 +67,7 @@ where
 
     /// A convenience method to convert [`Coeff::MODULUS`](PrimeField::MODULUS) to `u128`.
     fn modulus_as_u128() -> u128 {
-        debug_assert!(Self::check_constraints());
+        // We can't check constraints here, because this method is called by the constraint checks.
 
         let modulus: BigUint = Self::Coeff::MODULUS.into();
 

--- a/eyelid-match-ops/src/primitives/yashe/conf.rs
+++ b/eyelid-match-ops/src/primitives/yashe/conf.rs
@@ -10,10 +10,7 @@ use ark_ff::PrimeField;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
-use crate::primitives::poly::{
-    modular_poly::conf::{FullRes, IrisBits},
-    PolyConf,
-};
+use crate::{primitives::poly::PolyConf, FullRes, IrisBits};
 
 #[cfg(tiny_poly)]
 use crate::TinyTest;

--- a/eyelid-match-ops/src/primitives/yashe/conf.rs
+++ b/eyelid-match-ops/src/primitives/yashe/conf.rs
@@ -6,18 +6,10 @@
 //! RUSTFLAGS="--cfg tiny_poly" cargo bench --features benchmark
 //! ```
 
-use crate::{
-    primitives::poly::{modular_poly::conf::IrisBits, PolyConf},
-    IRIS_BIT_LENGTH,
-};
-
-pub use crate::primitives::poly::modular_poly::conf::TestRes;
-
-#[cfg(not(tiny_poly))]
-use crate::primitives::poly::modular_poly::conf::FullRes;
+use crate::{primitives::poly::PolyConf, FullRes, IrisBits};
 
 #[cfg(tiny_poly)]
-use crate::primitives::poly::modular_poly::conf::TinyTest;
+use crate::TinyTest;
 
 /// Fixed YASHE encryption scheme parameters.
 /// The [`PolyConf`] supertrait is the configuration of the polynomials used in the scheme.
@@ -43,7 +35,7 @@ where
 ///
 /// This uses the full number of iris bits, which gives an upper bound on benchmarks.
 impl YasheConf for IrisBits {
-    const T: u64 = IRIS_BIT_LENGTH as u64;
+    const T: u64 = crate::IRIS_BIT_LENGTH as u64;
 
     const DELTA: f64 = 3.2;
 }
@@ -51,7 +43,6 @@ impl YasheConf for IrisBits {
 /// Full resolution polynomial parameters.
 ///
 /// These are the parameters for full resolution, according to the Inversed Tech report.
-#[cfg(not(tiny_poly))]
 impl YasheConf for FullRes {
     const T: u64 = 1024;
 

--- a/eyelid-match-ops/src/primitives/yashe/conf.rs
+++ b/eyelid-match-ops/src/primitives/yashe/conf.rs
@@ -6,7 +6,7 @@
 //! RUSTFLAGS="--cfg tiny_poly" cargo bench --features benchmark
 //! ```
 
-use crate::{primitives::poly::PolyConf, FullRes, IrisBits};
+use crate::{iris::conf::IrisConf, primitives::poly::PolyConf, FullRes, IrisBits};
 
 #[cfg(tiny_poly)]
 use crate::TinyTest;
@@ -35,10 +35,15 @@ where
 ///
 /// This uses the full number of iris bits, which gives an upper bound on benchmarks.
 impl YasheConf for IrisBits {
-    const T: u64 = crate::IRIS_BIT_LENGTH as u64;
+    const T: u64 = Self::BIT_LENGTH as u64;
 
     const DELTA: f64 = 3.2;
 }
+// TODO: work out how to constant assert these constraints for each config type:
+// The encrypted coefficient modulus can't be smaller than the plaintext modulus.
+// const_assert!(IrisBits::T <= <IrisBits as PolyConf>::Coeff::MODULUS as u128);
+// The standard deviation must fit within the encrypted coefficient modulus, with six sigma probability.
+// const_assert!(IrisBits::DELTA <= <IrisBits as PolyConf>::Coeff::MODULUS as f64 / 6.0);
 
 /// Full resolution polynomial parameters.
 ///

--- a/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
@@ -1,8 +1,8 @@
 //! Unit tests for Encryption and Decryption
 
-use crate::primitives::{
-    poly::{modular_poly::conf::FullRes, IrisBits},
-    yashe::{Yashe, YasheConf},
+use crate::{
+    primitives::yashe::{Yashe, YasheConf},
+    FullRes, IrisBits,
 };
 
 fn encrypt_decrypt_helper<C: YasheConf>()

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -1,11 +1,15 @@
 //! Unit tests for Key Generation
 
-use crate::primitives::{
-    poly::{Poly, TestRes},
-    yashe::{Yashe, YasheConf},
-};
 use ark_ff::One;
 use ark_poly::Polynomial;
+
+use crate::{
+    primitives::{
+        poly::Poly,
+        yashe::{Yashe, YasheConf},
+    },
+    TestRes,
+};
 
 /// Auxiliary function for testing key generation
 fn keygen_helper<C: YasheConf>()


### PR DESCRIPTION
This PR is part of ticket #84. The rest of ticket #84 can be completed once these PRs merge:
- [x] #81
- [x] #82

This PR:
- adds an `IrisConf` trait
- implements that trait for the existing configurations
- adds some assertions for constraints on configurations

It also has some cleanups:
- makes the existing iris constants aliases of the `IrisBits` impl of `IrisConf`
- moves the existing configurations to their own module
- cleans up some module imports

It might have some conflicts with other PRs, but hopefully only in module imports.
