### PR TITLE
fft-prime: use Fq that has 2-adic roots-of-unity

### DIFF
--- a/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
+++ b/eyelid-match-ops/src/primitives/poly/fq/fq79.rs
@@ -6,18 +6,32 @@
 use ark_ff::{Fp128, MontBackend, MontConfig};
 
 /// The configuration of the modular field used for polynomial coefficients.
-//
-// Sage commands:
-// random_prime(2**79)
-// 93309596432438992665667
-// ff = GF(93309596432438992665667)
-// ff.multiplicative_generator()
-// 5
-//
-// We could also consider generating primes dynamically, but this could impact performance.
+/* Generated with the following Sage commands:
+
+```sage
+maxi = 2**79
+for i in range(1000):
+    q = random_prime(maxi)
+    if (q - 1) % 2048 == 0:
+        print("OK", q)
+```
+
+```sage
+q = 495925933090739208380417
+assert 2**78 < q < 2**79
+assert q - 1 == 2**13 * 23 * 271 * 9712471302621631
+
+generator = GF(q).multiplicative_generator()
+omega = pow(generator, 23 * 271 * 9712471302621631, q)
+assert generator == 3
+assert omega == 460543614695341080498621
+assert pow(omega, 2**13, q) == 1
+assert pow(omega, 2**12, q) != 1
+```
+*/
 #[derive(MontConfig)]
-#[modulus = "93309596432438992665667"]
-#[generator = "5"]
+#[modulus = "495925933090739208380417"]
+#[generator = "3"]
 pub struct Fq79Config;
 
 /// The modular field used for polynomial coefficients, with precomputed primes and generators.


### PR DESCRIPTION
Switch to a prime field that has a multiplicative subgroup of order 2^13, suitable for potential FFT / NTT implementations.