### PR TITLE
Change iris dimensions to match the report, and fix encoded polynomial block configurations

### DIFF
--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -197,11 +197,6 @@ pub fn bench_naive_cyclotomic_mul(settings: &mut Criterion) {
 
 /// Run [`poly::naive_cyclotomic_mul()`] as a Criterion benchmark with random data on middle resolution.
 pub fn bench_naive_cyclotomic_mul_mid(settings: &mut Criterion) {
-    // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
-    // We can override the configuration on a per-group level
-    settings.sampling_mode(Flat);
-
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
     let p2: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
@@ -235,11 +230,6 @@ pub fn bench_rec_karatsuba_mul(settings: &mut Criterion) {
 
 /// Run [`poly::rec_karatsuba_mul()`] as a Criterion benchmark with random data on middle resolution.
 pub fn bench_rec_karatsuba_mul_mid(settings: &mut Criterion) {
-    // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
-    // We can override the configuration on a per-group level
-    settings.sampling_mode(Flat);
-
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
     let p2: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
@@ -273,17 +263,12 @@ pub fn bench_flat_karatsuba_mul(settings: &mut Criterion) {
 
 /// Run [`poly::flat_karatsuba_mul()`] as a Criterion benchmark with random data on middle resolution.
 pub fn bench_flat_karatsuba_mul_mid(settings: &mut Criterion) {
-    // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
-    // We can override the configuration on a per-group level
-    settings.sampling_mode(Flat);
-
     // Setup: generate random cyclotomic polynomials
     let p1: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
     let p2: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
 
     settings.bench_with_input(
-        BenchmarkId::new("Flat karatsuba mul full poly", RANDOM_BITS_NAME),
+        BenchmarkId::new("Flat karatsuba mul mid poly", RANDOM_BITS_NAME),
         &(p1, p2),
         |benchmark, (p1, p2)| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -389,11 +374,6 @@ pub fn bench_inv(settings: &mut Criterion) {
 
 /// Run [`poly::inverse()`] as a Criterion benchmark with gaussian random data on middle resolution.
 pub fn bench_inv_mid(settings: &mut Criterion) {
-    // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
-    // We can override the configuration on a per-group level
-    settings.sampling_mode(Flat);
-
     // Setup: generate random cyclotomic polynomials
 
     let mut rng = rand::thread_rng();
@@ -403,7 +383,7 @@ pub fn bench_inv_mid(settings: &mut Criterion) {
     let p = ctx.sample_key(&mut rng);
 
     settings.bench_with_input(
-        BenchmarkId::new("Inverse full poly", SMALL_RANDOM_NAME),
+        BenchmarkId::new("Inverse mid poly", SMALL_RANDOM_NAME),
         &(p),
         |benchmark, p| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.
@@ -525,16 +505,11 @@ pub fn bench_yashe_cipher_mul(settings: &mut Criterion) {
 
 /// Run [`Yashe::keygen()`] as a Criterion benchmark with random data on middle resolution.
 pub fn bench_keygen_mid(settings: &mut Criterion) {
-    // Tweak configuration for a long-running test
-    let mut settings = settings.benchmark_group(SLOW_BENCH_NAME);
-    // We can override the configuration on a per-group level
-    settings.sampling_mode(Flat);
-
     // Setup parameters
     let ctx: Yashe<MiddleRes> = Yashe::new();
 
     settings.bench_with_input(
-        BenchmarkId::new("YASHE full keygen", SMALL_RANDOM_NAME),
+        BenchmarkId::new("YASHE mid keygen", SMALL_RANDOM_NAME),
         &ctx,
         |benchmark, ctx| {
             // To avoid timing dropping the return value, we require it to be returned from the closure.

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -156,7 +156,7 @@ pub const SMALL_RANDOM_NAME: &str = "small rand";
 
 /// Run [`plaintext::is_iris_match()`] as a Criterion benchmark with random data.
 fn bench_plaintext_full_match(settings: &mut Criterion) {
-    use eyelid_match_ops::IrisBits;
+    use eyelid_match_ops::FullBits;
 
     // Setup: generate different random iris codes and masks
     let eye_new = random_iris_code();
@@ -170,7 +170,7 @@ fn bench_plaintext_full_match(settings: &mut Criterion) {
         |benchmark, (eye_new, mask_new, eye_store, mask_store)| {
             benchmark.iter_with_large_drop(|| {
                 // To avoid timing dropping the return value, this line must not end in ';'
-                plaintext::is_iris_match::<IrisBits, { IrisBits::STORE_ELEM_LEN }>(
+                plaintext::is_iris_match::<FullBits, { FullBits::STORE_ELEM_LEN }>(
                     eye_new, mask_new, eye_store, mask_store,
                 )
             })

--- a/eyelid-match-ops/benches/match-ops.rs
+++ b/eyelid-match-ops/benches/match-ops.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode::*};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use eyelid_match_ops::{
     plaintext::{

--- a/eyelid-match-ops/src/conf.rs
+++ b/eyelid-match-ops/src/conf.rs
@@ -6,7 +6,6 @@
 ///
 /// This uses the full number of iris bits, which gives an upper bound on benchmarks.
 ///
-/// TODO: Rename to FullBits
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct FullBits;
 

--- a/eyelid-match-ops/src/conf.rs
+++ b/eyelid-match-ops/src/conf.rs
@@ -8,7 +8,7 @@
 ///
 /// TODO: Rename to FullBits
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct IrisBits;
+pub struct FullBits;
 
 /// Raw middle resolution iris code dimensions.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -26,7 +26,7 @@ pub struct TinyTest;
 //
 // We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
 #[cfg(not(tiny_poly))]
-pub type TestBits = IrisBits;
+pub type TestBits = FullBits;
 
 /// The polynomial config used in tests.
 ///

--- a/eyelid-match-ops/src/conf.rs
+++ b/eyelid-match-ops/src/conf.rs
@@ -2,11 +2,31 @@
 //! Any or all of the configuration traits can be implemented on these types, or your own custom
 //! types.
 
+/// Raw full resolution iris code dimensions.
+///
+/// This uses the full number of iris bits, which gives an upper bound on benchmarks.
+///
+/// TODO: Rename to FullBits
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct IrisBits;
+
+/// Raw middle resolution iris code dimensions.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct MiddleBits;
+
+/// Tiny test polynomials, used for finding edge cases in tests.
+/// Used for both a tiny resolution and a tiny block encoding.
+///
+/// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
+#[cfg(tiny_poly)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TinyTest;
+
 /// The polynomial config used in tests.
 //
 // We use the full resolution by default, but TinyTest when cfg(tiny_poly) is set.
 #[cfg(not(tiny_poly))]
-pub type TestRes = FullRes;
+pub type TestBits = IrisBits;
 
 /// The polynomial config used in tests.
 ///
@@ -16,29 +36,4 @@ pub type TestRes = FullRes;
 /// RUSTFLAGS="--cfg tiny_poly" cargo bench --features benchmark
 /// ```
 #[cfg(tiny_poly)]
-pub type TestRes = TinyTest;
-
-/// Iris bit length polynomial parameters.
-///
-/// This uses the full number of iris bits, which gives an upper bound on benchmarks.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct IrisBits;
-
-/// Full resolution polynomial parameters.
-///
-/// These are the parameters for full resolution, according to the Inversed Tech report.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct FullRes;
-
-/// Middle resolution polynomial parameters.
-///
-/// These are the parameters for middle resolution, according to the Inversed Tech report.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct MiddleRes;
-
-/// Tiny test polynomials, used for finding edge cases in tests.
-///
-/// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
-#[cfg(tiny_poly)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct TinyTest;
+pub type TestBits = TinyTest;

--- a/eyelid-match-ops/src/encoded.rs
+++ b/eyelid-match-ops/src/encoded.rs
@@ -10,7 +10,10 @@ use crate::{
     primitives::poly::{Poly, PolyConf},
 };
 
-pub use conf::EncodeConf;
+pub use conf::{EncodeConf, FullRes, MiddleRes};
+
+#[cfg(any(test, feature = "benchmark"))]
+pub use conf::TestRes;
 
 pub mod conf;
 

--- a/eyelid-match-ops/src/encoded/conf.rs
+++ b/eyelid-match-ops/src/encoded/conf.rs
@@ -105,7 +105,7 @@ impl EncodeConf for TinyTest {
     type EyeConf = TinyTest;
     type PlainConf = TinyTest;
 
-    const ROWS_PER_BLOCK: usize = 2;
+    const ROWS_PER_BLOCK: usize = 1;
 }
 
 /// This module avoids repeating `#[cfg(tiny_poly)]` for each assertion.

--- a/eyelid-match-ops/src/encoded/conf.rs
+++ b/eyelid-match-ops/src/encoded/conf.rs
@@ -21,7 +21,7 @@ pub trait EncodeConf {
 
     /// Divide iris codes into blocks that can each fit into a polynomial.
     /// The number of rows in each block: `s`
-    const ROWS_PER_BLOCK: usize = 10;
+    const ROWS_PER_BLOCK: usize;
 
     /// The number of iris bits in each block.
     const BLOCK_BIT_LEN: usize = Self::EyeConf::COLUMN_LEN * Self::ROWS_PER_BLOCK;
@@ -95,7 +95,7 @@ impl EncodeConf for FullRes {
     type EyeConf = FullRes;
     type PlainConf = FullRes;
 
-    const ROWS_PER_BLOCK: usize = 10;
+    const ROWS_PER_BLOCK: usize = 16;
 }
 const_assert!(FullRes::ROWS_PER_BLOCK <= FullRes::COLUMN_LEN);
 const_assert_eq!(
@@ -111,7 +111,7 @@ impl EncodeConf for MiddleRes {
     type EyeConf = MiddleRes;
     type PlainConf = MiddleRes;
 
-    const ROWS_PER_BLOCK: usize = 5;
+    const ROWS_PER_BLOCK: usize = 8;
 }
 const_assert!(MiddleRes::ROWS_PER_BLOCK <= MiddleRes::COLUMN_LEN);
 const_assert_eq!(

--- a/eyelid-match-ops/src/encoded/conf.rs
+++ b/eyelid-match-ops/src/encoded/conf.rs
@@ -14,7 +14,7 @@ use crate::TinyTest;
 pub trait EncodeConf {
     /// The configuration of iris code data.
     ///
-    /// TODO: rename to EyeBits?
+    /// TODO: rename to EyeData and DataConf?
     type EyeConf: IrisConf;
 
     /// The configuration of plaintext polynomials.
@@ -71,7 +71,6 @@ impl EncodeConf for FullBits {
     type EyeConf = FullBits;
     type PlainConf = FullRes;
 
-    // TODO: using 16 fails with an encryption positive multiplication test error
     const ROWS_PER_BLOCK: usize = 8;
 }
 // As in the report

--- a/eyelid-match-ops/src/encoded/conf.rs
+++ b/eyelid-match-ops/src/encoded/conf.rs
@@ -71,8 +71,15 @@ impl EncodeConf for FullBits {
     type EyeConf = FullBits;
     type PlainConf = FullRes;
 
-    const ROWS_PER_BLOCK: usize = 16;
+    // TODO: using 16 fails with an encryption positive multiplication test error
+    const ROWS_PER_BLOCK: usize = 8;
 }
+// As in the report
+const_assert_eq!(
+    <<FullBits as EncodeConf>::PlainConf as PolyConf>::MAX_POLY_DEGREE,
+    2048
+);
+
 // TODO: work out how to automatically apply these assertions to every trait impl.
 // (Or every config type.)
 //
@@ -93,8 +100,14 @@ impl EncodeConf for MiddleBits {
     type EyeConf = MiddleBits;
     type PlainConf = MiddleRes;
 
-    const ROWS_PER_BLOCK: usize = 8;
+    const ROWS_PER_BLOCK: usize = 4;
 }
+// As in the report
+const_assert_eq!(
+    <<MiddleBits as EncodeConf>::PlainConf as PolyConf>::MAX_POLY_DEGREE,
+    1024
+);
+
 const_assert!(MiddleBits::ROWS_PER_BLOCK <= MiddleBits::COLUMN_LEN);
 const_assert_eq!(
     MiddleBits::NUM_BLOCKS * MiddleBits::ROWS_PER_BLOCK,

--- a/eyelid-match-ops/src/encoded/conf.rs
+++ b/eyelid-match-ops/src/encoded/conf.rs
@@ -4,7 +4,7 @@ use ark_ff::{One, Zero};
 use num_bigint::BigUint;
 
 use crate::{
-    encoded::MatchError, iris::conf::IrisConf, primitives::poly::PolyConf, IrisBits, MiddleBits,
+    encoded::MatchError, iris::conf::IrisConf, primitives::poly::PolyConf, FullBits, MiddleBits,
 };
 
 #[cfg(tiny_poly)]
@@ -67,8 +67,8 @@ pub trait EncodeConf {
     }
 }
 
-impl EncodeConf for IrisBits {
-    type EyeConf = IrisBits;
+impl EncodeConf for FullBits {
+    type EyeConf = FullBits;
     type PlainConf = FullRes;
 
     const ROWS_PER_BLOCK: usize = 16;
@@ -77,16 +77,16 @@ impl EncodeConf for IrisBits {
 // (Or every config type.)
 //
 // We can't have more rows per block than actual rows.
-const_assert!(IrisBits::ROWS_PER_BLOCK <= IrisBits::COLUMN_LEN);
+const_assert!(FullBits::ROWS_PER_BLOCK <= FullBits::COLUMN_LEN);
 // Only full blocks are supported at the moment.
 const_assert_eq!(
-    IrisBits::NUM_BLOCKS * IrisBits::ROWS_PER_BLOCK,
-    IrisBits::COLUMN_LEN
+    FullBits::NUM_BLOCKS * FullBits::ROWS_PER_BLOCK,
+    FullBits::COLUMN_LEN
 );
 // Each block must be able to be encoded into the configured polynomial.
 const_assert!(
-    IrisBits::NUM_COLS_AND_PADS * IrisBits::ROWS_PER_BLOCK
-        <= <<IrisBits as EncodeConf>::PlainConf as PolyConf>::MAX_POLY_DEGREE
+    FullBits::NUM_COLS_AND_PADS * FullBits::ROWS_PER_BLOCK
+        <= <<FullBits as EncodeConf>::PlainConf as PolyConf>::MAX_POLY_DEGREE
 );
 
 impl EncodeConf for MiddleBits {

--- a/eyelid-match-ops/src/encoded/test/matching.rs
+++ b/eyelid-match-ops/src/encoded/test/matching.rs
@@ -4,25 +4,25 @@ use crate::{
     encoded::{PolyCode, PolyQuery},
     iris::conf::IrisConf,
     plaintext::test::matching::{different, matching},
-    FullRes, IrisBits, TestRes,
+    MiddleBits, TestBits,
 };
 
 /// Check matching test cases.
 #[test]
 fn matching_codes() {
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        matching::<TestRes, { TestRes::STORE_ELEM_LEN }>().iter()
+        matching::<TestBits, { TestBits::STORE_ELEM_LEN }>().iter()
     {
-        let poly_query: PolyQuery<TestRes> = PolyQuery::from_plaintext(eye_a, mask_a);
+        let poly_query: PolyQuery<TestBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
         assert!(res, "{} must match", description);
     }
 
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        matching::<IrisBits, { IrisBits::STORE_ELEM_LEN }>().iter()
+        matching::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>().iter()
     {
-        let poly_query: PolyQuery<IrisBits> = PolyQuery::from_plaintext(eye_a, mask_a);
+        let poly_query: PolyQuery<MiddleBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
         assert!(res, "{} must match", description);
@@ -34,18 +34,18 @@ fn matching_codes() {
 fn different_codes() {
     // TODO: get this working with cfg(tiny_poly) and TestRes
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        different::<FullRes, { FullRes::STORE_ELEM_LEN }>().iter()
+        different::<TestBits, { TestBits::STORE_ELEM_LEN }>().iter()
     {
-        let poly_query: PolyQuery<FullRes> = PolyQuery::from_plaintext(eye_a, mask_a);
+        let poly_query: PolyQuery<TestBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
         assert!(!res, "{} must not match", description);
     }
 
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        different::<IrisBits, { IrisBits::STORE_ELEM_LEN }>().iter()
+        different::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>().iter()
     {
-        let poly_query: PolyQuery<IrisBits> = PolyQuery::from_plaintext(eye_a, mask_a);
+        let poly_query: PolyQuery<MiddleBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
         assert!(!res, "{} must not match", description);

--- a/eyelid-match-ops/src/encoded/test/matching.rs
+++ b/eyelid-match-ops/src/encoded/test/matching.rs
@@ -4,7 +4,7 @@ use crate::{
     encoded::{PolyCode, PolyQuery},
     iris::conf::IrisConf,
     plaintext::test::matching::{different, matching},
-    MiddleBits, TestBits,
+    FullBits, MiddleBits, TestBits,
 };
 
 /// Check matching test cases.
@@ -16,7 +16,12 @@ fn matching_codes() {
         let poly_query: PolyQuery<TestBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
-        assert!(res, "{} must match", description);
+        assert!(
+            res,
+            "{description} must match:\n\
+            query: {poly_query:?}\n\
+            code: {poly_code:?}"
+        );
     }
 
     for (description, eye_a, mask_a, eye_b, mask_b) in
@@ -25,22 +30,19 @@ fn matching_codes() {
         let poly_query: PolyQuery<MiddleBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
-        assert!(res, "{} must match", description);
+        assert!(
+            res,
+            "{description} must match:\n\
+            query: {poly_query:?}\n\
+            code: {poly_code:?}"
+        );
     }
 }
 
 /// Check different (non-matching) test cases.
 #[test]
 fn different_codes() {
-    // TODO: get this working with cfg(tiny_poly) and TestRes
-    for (description, eye_a, mask_a, eye_b, mask_b) in
-        different::<TestBits, { TestBits::STORE_ELEM_LEN }>().iter()
-    {
-        let poly_query: PolyQuery<TestBits> = PolyQuery::from_plaintext(eye_a, mask_a);
-        let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
-        let res = poly_query.is_match(&poly_code).expect("matching must work");
-        assert!(!res, "{} must not match", description);
-    }
+    // TODO: get this working with cfg(tiny_poly) and TestBits
 
     for (description, eye_a, mask_a, eye_b, mask_b) in
         different::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>().iter()
@@ -48,6 +50,25 @@ fn different_codes() {
         let poly_query: PolyQuery<MiddleBits> = PolyQuery::from_plaintext(eye_a, mask_a);
         let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
         let res = poly_query.is_match(&poly_code).expect("matching must work");
-        assert!(!res, "{} must not match", description);
+        assert!(
+            !res,
+            "{description} must not match:\n\
+            query: {poly_query:?}\n\
+            code: {poly_code:?}"
+        );
+    }
+
+    for (description, eye_a, mask_a, eye_b, mask_b) in
+        different::<FullBits, { FullBits::STORE_ELEM_LEN }>().iter()
+    {
+        let poly_query: PolyQuery<FullBits> = PolyQuery::from_plaintext(eye_a, mask_a);
+        let poly_code = PolyCode::from_plaintext(eye_b, mask_b);
+        let res = poly_query.is_match(&poly_code).expect("matching must work");
+        assert!(
+            !res,
+            "{description} must not match:\n\
+            query: {poly_query:?}\n\
+            code: {poly_code:?}"
+        );
     }
 }

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -6,7 +6,7 @@ use std::mem::size_of;
 
 use bitvec::{mem::elts, prelude::BitArray};
 
-use crate::{FullRes, IrisBits, MiddleRes};
+use crate::{IrisBits, MiddleBits};
 
 #[cfg(tiny_poly)]
 use crate::TinyTest;
@@ -86,27 +86,16 @@ const_assert!(IrisBits::ROTATION_COMPARISONS <= IrisBits::COLUMNS);
 const_assert!(IrisBits::MATCH_NUMERATOR <= IrisBits::MATCH_DENOMINATOR);
 const_assert!(IrisBits::MATCH_DENOMINATOR > 0);
 
-impl IrisConf for FullRes {
-    const COLUMNS: usize = 200;
-    const COLUMN_LEN: usize = 16 * 2 * 2;
-    const ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
-}
-const_assert!(FullRes::DATA_BIT_LEN >= FullRes::COLUMN_LEN * FullRes::COLUMNS);
-const_assert!(FullRes::STORE_ELEM_LEN * size_of::<IrisStore>() * 8 >= FullRes::DATA_BIT_LEN);
-const_assert!(FullRes::ROTATION_COMPARISONS <= FullRes::COLUMNS);
-const_assert!(FullRes::MATCH_NUMERATOR <= FullRes::MATCH_DENOMINATOR);
-const_assert!(FullRes::MATCH_DENOMINATOR > 0);
-
-impl IrisConf for MiddleRes {
+impl IrisConf for MiddleBits {
     const COLUMNS: usize = 100;
     const COLUMN_LEN: usize = 8 * 2 * 2;
     const ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
 }
-const_assert!(MiddleRes::DATA_BIT_LEN >= MiddleRes::COLUMN_LEN * MiddleRes::COLUMNS);
-const_assert!(MiddleRes::STORE_ELEM_LEN * size_of::<IrisStore>() * 8 >= MiddleRes::DATA_BIT_LEN);
-const_assert!(MiddleRes::ROTATION_COMPARISONS <= MiddleRes::COLUMNS);
-const_assert!(MiddleRes::MATCH_NUMERATOR <= MiddleRes::MATCH_DENOMINATOR);
-const_assert!(MiddleRes::MATCH_DENOMINATOR > 0);
+const_assert!(MiddleBits::DATA_BIT_LEN >= MiddleBits::COLUMN_LEN * MiddleBits::COLUMNS);
+const_assert!(MiddleBits::STORE_ELEM_LEN * size_of::<IrisStore>() * 8 >= MiddleBits::DATA_BIT_LEN);
+const_assert!(MiddleBits::ROTATION_COMPARISONS <= MiddleBits::COLUMNS);
+const_assert!(MiddleBits::MATCH_NUMERATOR <= MiddleBits::MATCH_DENOMINATOR);
+const_assert!(MiddleBits::MATCH_DENOMINATOR > 0);
 
 #[cfg(tiny_poly)]
 impl IrisConf for TinyTest {

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -11,7 +11,7 @@ use crate::{FullRes, IrisBits, MiddleRes};
 #[cfg(tiny_poly)]
 use crate::TinyTest;
 
-/// The dimensions and matching rules for iris codes.
+/// The dimensions and matching rules for the entire iris code.
 pub trait IrisConf {
     /// The number of rows in an iris code or iris mask.
     //

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -13,13 +13,13 @@ use crate::TinyTest;
 
 /// The dimensions and matching rules for the entire iris code.
 pub trait IrisConf {
+    /// The number of columns in an iris code or mask, `k`.
+    const COLUMNS: usize;
+
     /// The number of rows in an iris code or iris mask.
     //
     // TODO: rename to `ROWS`
     const COLUMN_LEN: usize;
-
-    /// The number of columns in an iris code or mask, `k`.
-    const COLUMNS: usize;
 
     /// The length of an iris code or mask.
     const DATA_BIT_LEN: usize = Self::COLUMN_LEN * Self::COLUMNS;
@@ -70,8 +70,8 @@ pub type IrisCode<const STORE_ELEM_LEN: usize> = BitArray<[IrisStore; STORE_ELEM
 pub type IrisMask<const STORE_ELEM_LEN: usize> = BitArray<[IrisStore; STORE_ELEM_LEN]>;
 
 impl IrisConf for IrisBits {
-    const COLUMN_LEN: usize = 80;
-    const COLUMNS: usize = 160;
+    const COLUMNS: usize = 200;
+    const COLUMN_LEN: usize = 16 * 2 * 2;
     const ROTATION_LIMIT: usize = 15;
 }
 // TODO: work out how to automatically apply these assertions to every trait impl.
@@ -87,8 +87,8 @@ const_assert!(IrisBits::MATCH_NUMERATOR <= IrisBits::MATCH_DENOMINATOR);
 const_assert!(IrisBits::MATCH_DENOMINATOR > 0);
 
 impl IrisConf for FullRes {
-    const COLUMN_LEN: usize = 10;
-    const COLUMNS: usize = 160;
+    const COLUMNS: usize = 200;
+    const COLUMN_LEN: usize = 16 * 2 * 2;
     const ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
 }
 const_assert!(FullRes::DATA_BIT_LEN >= FullRes::COLUMN_LEN * FullRes::COLUMNS);
@@ -98,8 +98,8 @@ const_assert!(FullRes::MATCH_NUMERATOR <= FullRes::MATCH_DENOMINATOR);
 const_assert!(FullRes::MATCH_DENOMINATOR > 0);
 
 impl IrisConf for MiddleRes {
-    const COLUMN_LEN: usize = 5;
-    const COLUMNS: usize = 80;
+    const COLUMNS: usize = 100;
+    const COLUMN_LEN: usize = 8 * 2 * 2;
     const ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
 }
 const_assert!(MiddleRes::DATA_BIT_LEN >= MiddleRes::COLUMN_LEN * MiddleRes::COLUMNS);
@@ -110,8 +110,8 @@ const_assert!(MiddleRes::MATCH_DENOMINATOR > 0);
 
 #[cfg(tiny_poly)]
 impl IrisConf for TinyTest {
-    const COLUMN_LEN: usize = 2;
     const COLUMNS: usize = 3;
+    const COLUMN_LEN: usize = 2;
     const ROTATION_LIMIT: usize = 1;
 }
 

--- a/eyelid-match-ops/src/iris/conf.rs
+++ b/eyelid-match-ops/src/iris/conf.rs
@@ -6,7 +6,7 @@ use std::mem::size_of;
 
 use bitvec::{mem::elts, prelude::BitArray};
 
-use crate::{IrisBits, MiddleBits};
+use crate::{FullBits, MiddleBits};
 
 #[cfg(tiny_poly)]
 use crate::TinyTest;
@@ -69,7 +69,7 @@ pub type IrisCode<const STORE_ELEM_LEN: usize> = BitArray<[IrisStore; STORE_ELEM
 ///       correctly.
 pub type IrisMask<const STORE_ELEM_LEN: usize> = BitArray<[IrisStore; STORE_ELEM_LEN]>;
 
-impl IrisConf for IrisBits {
+impl IrisConf for FullBits {
     const COLUMNS: usize = 200;
     const COLUMN_LEN: usize = 16 * 2 * 2;
     const ROTATION_LIMIT: usize = 15;
@@ -78,18 +78,18 @@ impl IrisConf for IrisBits {
 // (Or every config type.)
 //
 // There must be enough bits to store the underlying data.
-const_assert!(IrisBits::DATA_BIT_LEN >= IrisBits::COLUMN_LEN * IrisBits::COLUMNS);
-const_assert!(IrisBits::STORE_ELEM_LEN * size_of::<IrisStore>() * 8 >= IrisBits::DATA_BIT_LEN);
+const_assert!(FullBits::DATA_BIT_LEN >= FullBits::COLUMN_LEN * FullBits::COLUMNS);
+const_assert!(FullBits::STORE_ELEM_LEN * size_of::<IrisStore>() * 8 >= FullBits::DATA_BIT_LEN);
 // Rotating more than the number of columns is redundant.
-const_assert!(IrisBits::ROTATION_COMPARISONS <= IrisBits::COLUMNS);
+const_assert!(FullBits::ROTATION_COMPARISONS <= FullBits::COLUMNS);
 // The match fraction should be between 0 and 1.
-const_assert!(IrisBits::MATCH_NUMERATOR <= IrisBits::MATCH_DENOMINATOR);
-const_assert!(IrisBits::MATCH_DENOMINATOR > 0);
+const_assert!(FullBits::MATCH_NUMERATOR <= FullBits::MATCH_DENOMINATOR);
+const_assert!(FullBits::MATCH_DENOMINATOR > 0);
 
 impl IrisConf for MiddleBits {
     const COLUMNS: usize = 100;
     const COLUMN_LEN: usize = 8 * 2 * 2;
-    const ROTATION_LIMIT: usize = IrisBits::ROTATION_LIMIT;
+    const ROTATION_LIMIT: usize = FullBits::ROTATION_LIMIT;
 }
 const_assert!(MiddleBits::DATA_BIT_LEN >= MiddleBits::COLUMN_LEN * MiddleBits::COLUMNS);
 const_assert!(MiddleBits::STORE_ELEM_LEN * size_of::<IrisStore>() * 8 >= MiddleBits::DATA_BIT_LEN);

--- a/eyelid-match-ops/src/lib.rs
+++ b/eyelid-match-ops/src/lib.rs
@@ -22,10 +22,16 @@ pub mod iris;
 pub mod plaintext;
 pub mod primitives;
 
-pub use conf::{FullRes, IrisBits, MiddleRes};
+pub use conf::{IrisBits, MiddleBits};
+pub use encoded::{EncodeConf, FullRes, MiddleRes};
+pub use iris::conf::IrisConf;
+pub use primitives::{poly::PolyConf, yashe::YasheConf};
 
 #[cfg(any(test, feature = "benchmark"))]
-pub use conf::TestRes;
+pub use conf::TestBits;
+
+#[cfg(any(test, feature = "benchmark"))]
+pub use encoded::TestRes;
 
 #[cfg(tiny_poly)]
 pub use conf::TinyTest;

--- a/eyelid-match-ops/src/lib.rs
+++ b/eyelid-match-ops/src/lib.rs
@@ -22,7 +22,7 @@ pub mod iris;
 pub mod plaintext;
 pub mod primitives;
 
-pub use conf::{IrisBits, MiddleBits};
+pub use conf::{FullBits, MiddleBits};
 pub use encoded::{EncodeConf, FullRes, MiddleRes};
 pub use iris::conf::IrisConf;
 pub use primitives::{poly::PolyConf, yashe::YasheConf};

--- a/eyelid-match-ops/src/plaintext/test/matching.rs
+++ b/eyelid-match-ops/src/plaintext/test/matching.rs
@@ -109,34 +109,33 @@ pub fn different<C: IrisConf, const STORE_ELEM_LEN: usize>() -> Vec<(
     IrisCode<STORE_ELEM_LEN>,
     IrisMask<STORE_ELEM_LEN>,
 )> {
-    let same_rand = random_iris_code();
-
     #[allow(unused_mut)]
-    let mut res = vec![
-        (
-            "set/unset, visible".to_string(),
-            set_iris_code(),
-            visible_iris_mask(),
-            unset_iris_code(),
-            visible_iris_mask(),
-        ),
-        (
-            "inverted rand, visible".to_string(),
-            same_rand,
-            visible_iris_mask(),
-            !same_rand,
-            visible_iris_mask(),
-        ),
-    ];
+    let mut res = vec![(
+        "set/unset, visible".to_string(),
+        set_iris_code(),
+        visible_iris_mask(),
+        unset_iris_code(),
+        visible_iris_mask(),
+    )];
 
     // In small polynomials these tests can fail by chance.
     #[cfg(not(tiny_poly))]
     {
         use crate::plaintext::test::gen::rotate_too_much;
 
+        let same_rand = random_iris_code();
         let iris2 = random_iris_code();
         let iris3 = rotate_too_much::<C, STORE_ELEM_LEN>(&iris2);
 
+        // A small random polynomial can be its own (rotated) inverse by chance
+        res.push((
+            "inverted rand, visible".to_string(),
+            same_rand,
+            visible_iris_mask(),
+            !same_rand,
+            visible_iris_mask(),
+        ));
+        // Two small random polynomials can match (under rotation) by chance
         res.push((
             "different".to_string(),
             same_rand,
@@ -144,7 +143,7 @@ pub fn different<C: IrisConf, const STORE_ELEM_LEN: usize>() -> Vec<(
             iris2,
             visible_iris_mask(),
         ));
-        #[cfg(not(tiny_poly))]
+        // An over-rotated polynomial can be its own inverse by chance
         res.push((
             "too much rotated".to_string(),
             iris2,

--- a/eyelid-match-ops/src/plaintext/test/matching.rs
+++ b/eyelid-match-ops/src/plaintext/test/matching.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[cfg(test)]
-use super::assert_iris_compare;
+use crate::{plaintext::test::assert_iris_compare, MiddleBits, TestBits};
 
 /// Returns a list of mask combinations which are always occluded.
 pub fn occluded<const STORE_ELEM_LEN: usize>(
@@ -160,12 +160,10 @@ pub fn different<C: IrisConf, const STORE_ELEM_LEN: usize>() -> Vec<(
 /// Check matching test cases.
 #[test]
 fn matching_codes() {
-    use crate::{IrisBits, TestRes};
-
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        matching::<TestRes, { TestRes::STORE_ELEM_LEN }>().iter()
+        matching::<TestBits, { TestBits::STORE_ELEM_LEN }>().iter()
     {
-        assert_iris_compare::<TestRes, { TestRes::STORE_ELEM_LEN }>(
+        assert_iris_compare::<TestBits, { TestBits::STORE_ELEM_LEN }>(
             true,
             description,
             eye_a,
@@ -176,9 +174,9 @@ fn matching_codes() {
     }
 
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        matching::<IrisBits, { IrisBits::STORE_ELEM_LEN }>().iter()
+        matching::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>().iter()
     {
-        assert_iris_compare::<IrisBits, { IrisBits::STORE_ELEM_LEN }>(
+        assert_iris_compare::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>(
             true,
             description,
             eye_a,
@@ -192,12 +190,10 @@ fn matching_codes() {
 /// Check different (non-matching) test cases.
 #[test]
 fn different_codes() {
-    use crate::{IrisBits, TestRes};
-
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        different::<TestRes, { TestRes::STORE_ELEM_LEN }>().iter()
+        different::<TestBits, { TestBits::STORE_ELEM_LEN }>().iter()
     {
-        assert_iris_compare::<TestRes, { TestRes::STORE_ELEM_LEN }>(
+        assert_iris_compare::<TestBits, { TestBits::STORE_ELEM_LEN }>(
             false,
             description,
             eye_a,
@@ -208,9 +204,9 @@ fn different_codes() {
     }
 
     for (description, eye_a, mask_a, eye_b, mask_b) in
-        different::<IrisBits, { IrisBits::STORE_ELEM_LEN }>().iter()
+        different::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>().iter()
     {
-        assert_iris_compare::<IrisBits, { IrisBits::STORE_ELEM_LEN }>(
+        assert_iris_compare::<MiddleBits, { MiddleBits::STORE_ELEM_LEN }>(
             false,
             description,
             eye_a,

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -89,7 +89,7 @@ lazy_static! {
 }
 
 impl PolyConf for FullRes {
-    const MAX_POLY_DEGREE: usize = 2048;
+    const MAX_POLY_DEGREE: usize = FullRes::DATA_BIT_LEN.next_power_of_two();
 
     type Coeff = Fq79;
 
@@ -113,7 +113,7 @@ const_assert!(FullResBN::MAX_POLY_DEGREE >= FullRes::DATA_BIT_LEN);
 const_assert!(FullResBN::MAX_POLY_DEGREE.count_ones() == 1);
 
 impl PolyConf for MiddleRes {
-    const MAX_POLY_DEGREE: usize = 1024;
+    const MAX_POLY_DEGREE: usize = MiddleRes::DATA_BIT_LEN.next_power_of_two();
 
     type Coeff = Fq66;
 
@@ -138,7 +138,7 @@ const_assert!(MiddleResBN::MAX_POLY_DEGREE.count_ones() == 1);
 
 #[cfg(tiny_poly)]
 impl PolyConf for TinyTest {
-    const MAX_POLY_DEGREE: usize = 16;
+    const MAX_POLY_DEGREE: usize = TinyTest::DATA_BIT_LEN.next_power_of_two();
 
     type Coeff = FqTiny;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -6,6 +6,7 @@ use ark_ff::{PrimeField, Zero};
 use lazy_static::lazy_static;
 
 use crate::{
+    encoded::EncodeConf,
     iris::conf::IrisConf,
     primitives::poly::{Fq66, Fq66bn, Fq79, Fq79bn},
     FullRes, IrisBits, MiddleRes,
@@ -43,8 +44,7 @@ pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
 }
 
 impl PolyConf for IrisBits {
-    // This degree requires a larger modulus, Fq79 doesn't work
-    const MAX_POLY_DEGREE: usize = IrisBits::DATA_BIT_LEN.next_power_of_two();
+    const MAX_POLY_DEGREE: usize = IrisBits::BLOCK_AND_PADS_BIT_LEN.next_power_of_two();
 
     type Coeff = Fq79;
 
@@ -89,7 +89,7 @@ lazy_static! {
 }
 
 impl PolyConf for FullRes {
-    const MAX_POLY_DEGREE: usize = FullRes::DATA_BIT_LEN.next_power_of_two();
+    const MAX_POLY_DEGREE: usize = FullRes::BLOCK_AND_PADS_BIT_LEN.next_power_of_two();
 
     type Coeff = Fq79;
 
@@ -113,7 +113,7 @@ const_assert!(FullResBN::MAX_POLY_DEGREE >= FullRes::DATA_BIT_LEN);
 const_assert!(FullResBN::MAX_POLY_DEGREE.count_ones() == 1);
 
 impl PolyConf for MiddleRes {
-    const MAX_POLY_DEGREE: usize = MiddleRes::DATA_BIT_LEN.next_power_of_two();
+    const MAX_POLY_DEGREE: usize = MiddleRes::BLOCK_AND_PADS_BIT_LEN.next_power_of_two();
 
     type Coeff = Fq66;
 
@@ -138,7 +138,7 @@ const_assert!(MiddleResBN::MAX_POLY_DEGREE.count_ones() == 1);
 
 #[cfg(tiny_poly)]
 impl PolyConf for TinyTest {
-    const MAX_POLY_DEGREE: usize = TinyTest::DATA_BIT_LEN.next_power_of_two();
+    const MAX_POLY_DEGREE: usize = TinyTest::BLOCK_AND_PADS_BIT_LEN.next_power_of_two();
 
     type Coeff = FqTiny;
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -8,7 +8,7 @@ use lazy_static::lazy_static;
 use crate::{
     encoded::{EncodeConf, FullRes, MiddleRes},
     primitives::poly::{Fq66, Fq66bn, Fq79, Fq79bn},
-    IrisBits, MiddleBits,
+    FullBits, MiddleBits,
 };
 
 #[cfg(tiny_poly)]
@@ -43,7 +43,7 @@ pub trait PolyConf: Copy + Clone + Debug + Eq + PartialEq {
 }
 
 impl PolyConf for FullRes {
-    const MAX_POLY_DEGREE: usize = IrisBits::BLOCK_AND_PADS_BIT_LEN.next_power_of_two();
+    const MAX_POLY_DEGREE: usize = FullBits::BLOCK_AND_PADS_BIT_LEN.next_power_of_two();
 
     type Coeff = Fq79;
 
@@ -52,7 +52,7 @@ impl PolyConf for FullRes {
     }
 }
 // The polynomial must have enough coefficients to store the underlying iris data.
-const_assert!(FullRes::MAX_POLY_DEGREE >= IrisBits::BLOCK_AND_PADS_BIT_LEN);
+const_assert!(FullRes::MAX_POLY_DEGREE >= FullBits::BLOCK_AND_PADS_BIT_LEN);
 // The degree must be a power of two.
 const_assert!(FullRes::MAX_POLY_DEGREE.count_ones() == 1);
 
@@ -67,7 +67,7 @@ impl PolyConf for FullResBN {
     }
 }
 // The polynomial must have enough coefficients to store the underlying iris data.
-const_assert!(FullResBN::MAX_POLY_DEGREE >= IrisBits::BLOCK_AND_PADS_BIT_LEN);
+const_assert!(FullResBN::MAX_POLY_DEGREE >= FullBits::BLOCK_AND_PADS_BIT_LEN);
 // The degree must be a power of two.
 const_assert!(FullResBN::MAX_POLY_DEGREE.count_ones() == 1);
 

--- a/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
+++ b/eyelid-match-ops/src/primitives/poly/modular_poly/conf.rs
@@ -7,7 +7,6 @@ use lazy_static::lazy_static;
 
 use crate::{
     encoded::EncodeConf,
-    iris::conf::IrisConf,
     primitives::poly::{Fq66, Fq66bn, Fq79, Fq79bn},
     FullRes, IrisBits, MiddleRes,
 };
@@ -53,7 +52,7 @@ impl PolyConf for IrisBits {
     }
 }
 // The polynomial must have enough coefficients to store the underlying iris data.
-const_assert!(IrisBits::MAX_POLY_DEGREE >= IrisBits::DATA_BIT_LEN);
+const_assert!(IrisBits::MAX_POLY_DEGREE >= IrisBits::BLOCK_AND_PADS_BIT_LEN);
 // The degree must be a power of two.
 const_assert!(IrisBits::MAX_POLY_DEGREE.count_ones() == 1);
 
@@ -68,7 +67,7 @@ impl PolyConf for IrisBitsBN {
     }
 }
 // The polynomial must have enough coefficients to store the underlying iris data.
-const_assert!(IrisBitsBN::MAX_POLY_DEGREE >= IrisBits::DATA_BIT_LEN);
+const_assert!(IrisBitsBN::MAX_POLY_DEGREE >= IrisBits::BLOCK_AND_PADS_BIT_LEN);
 // The degree must be a power of two.
 const_assert!(IrisBitsBN::MAX_POLY_DEGREE.count_ones() == 1);
 
@@ -97,7 +96,7 @@ impl PolyConf for FullRes {
         &FQ79_ZERO
     }
 }
-const_assert!(FullRes::MAX_POLY_DEGREE >= FullRes::DATA_BIT_LEN);
+const_assert!(FullRes::MAX_POLY_DEGREE >= FullRes::BLOCK_AND_PADS_BIT_LEN);
 const_assert!(FullRes::MAX_POLY_DEGREE.count_ones() == 1);
 
 impl PolyConf for FullResBN {
@@ -109,7 +108,7 @@ impl PolyConf for FullResBN {
         &FQ79_BN_ZERO
     }
 }
-const_assert!(FullResBN::MAX_POLY_DEGREE >= FullRes::DATA_BIT_LEN);
+const_assert!(FullResBN::MAX_POLY_DEGREE >= FullRes::BLOCK_AND_PADS_BIT_LEN);
 const_assert!(FullResBN::MAX_POLY_DEGREE.count_ones() == 1);
 
 impl PolyConf for MiddleRes {
@@ -121,7 +120,7 @@ impl PolyConf for MiddleRes {
         &FQ66_ZERO
     }
 }
-const_assert!(MiddleRes::MAX_POLY_DEGREE >= MiddleRes::DATA_BIT_LEN);
+const_assert!(MiddleRes::MAX_POLY_DEGREE >= MiddleRes::BLOCK_AND_PADS_BIT_LEN);
 const_assert!(MiddleRes::MAX_POLY_DEGREE.count_ones() == 1);
 
 impl PolyConf for MiddleResBN {
@@ -133,7 +132,7 @@ impl PolyConf for MiddleResBN {
         &FQ66_BN_ZERO
     }
 }
-const_assert!(MiddleResBN::MAX_POLY_DEGREE >= MiddleRes::DATA_BIT_LEN);
+const_assert!(MiddleResBN::MAX_POLY_DEGREE >= MiddleRes::BLOCK_AND_PADS_BIT_LEN);
 const_assert!(MiddleResBN::MAX_POLY_DEGREE.count_ones() == 1);
 
 #[cfg(tiny_poly)]
@@ -163,9 +162,9 @@ impl PolyConf for TinyTestBN {
 #[cfg(tiny_poly)]
 mod tiny_test_asserts {
     use super::*;
-    const_assert!(TinyTest::MAX_POLY_DEGREE >= TinyTest::DATA_BIT_LEN);
+    const_assert!(TinyTest::MAX_POLY_DEGREE >= TinyTest::BLOCK_AND_PADS_BIT_LEN);
     const_assert!(TinyTest::MAX_POLY_DEGREE.count_ones() == 1);
-    const_assert!(TinyTestBN::MAX_POLY_DEGREE >= TinyTest::DATA_BIT_LEN);
+    const_assert!(TinyTestBN::MAX_POLY_DEGREE >= TinyTest::BLOCK_AND_PADS_BIT_LEN);
     const_assert!(TinyTestBN::MAX_POLY_DEGREE.count_ones() == 1);
 }
 

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         yashe::Yashe,
     },
-    TestRes,
+    MiddleRes, TestRes,
 };
 
 fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {
@@ -57,11 +57,21 @@ fn test_key_generation_and_inverse() {
     // REMARK: For our parameter choices it is very likely to find
     // the inverse in the first attempt.
     inverse_test_helper(&f);
+
+    let ctx: Yashe<MiddleRes> = Yashe::new();
+    let f = ctx.sample_key(&mut rng);
+
+    // REMARK: For our parameter choices it is very likely to find
+    // the inverse in the first attempt.
+    inverse_test_helper(&f);
 }
 
 #[test]
 fn test_inverse_with_random_coefficients() {
     let f: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE);
+    inverse_test_helper(&f);
+
+    let f: Poly<MiddleRes> = rand_poly(MiddleRes::MAX_POLY_DEGREE);
     inverse_test_helper(&f);
 }
 
@@ -74,12 +84,26 @@ fn test_edge_cases() {
 
     // Inverse of minus one is minus one
     let zero_poly: Poly<TestRes> = Poly::zero();
-    let minus_one_poly = zero_poly - one_poly.clone();
+    let minus_one_poly = &zero_poly - one_poly.clone();
     out = inverse(&minus_one_poly.clone());
     assert_eq!(out, Ok(minus_one_poly));
 
     // Inverse of zero is error
-    let zero_poly: Poly<TestRes> = Poly::zero();
-    out = inverse(&zero_poly.clone());
+    out = inverse(&zero_poly);
+    assert!(out.is_err());
+
+    // Inverse of one is one
+    let one_poly: Poly<MiddleRes> = Poly::one();
+    let mut out = inverse(&one_poly.clone());
+    assert_eq!(out, Ok(one_poly.clone()));
+
+    // Inverse of minus one is minus one
+    let zero_poly: Poly<MiddleRes> = Poly::zero();
+    let minus_one_poly = &zero_poly - one_poly.clone();
+    out = inverse(&minus_one_poly.clone());
+    assert_eq!(out, Ok(minus_one_poly));
+
+    // Inverse of zero is error
+    out = inverse(&zero_poly);
     assert!(out.is_err());
 }

--- a/eyelid-match-ops/src/primitives/poly/test/inv.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/inv.rs
@@ -1,5 +1,7 @@
 //! Tests for polynomial inverse.
 
+use std::any::type_name;
+
 use ark_ff::{One, Zero};
 use ark_poly::Polynomial;
 
@@ -26,7 +28,12 @@ fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {
     let expect_msg = "just checked ok";
 
     if !cfg!(tiny_poly) || out.is_ok() {
-        assert_eq!(f * out.expect(expect_msg), Poly::one());
+        assert_eq!(
+            f * out.expect(expect_msg),
+            Poly::one(),
+            "{}",
+            type_name::<C>()
+        );
     } else {
         // For small degree and coefficient modulus, non-invertible polynomials are more likely.
 
@@ -38,11 +45,17 @@ fn inverse_test_helper<C: PolyConf>(f: &Poly<C>) {
         assert_ne!(
             fy,
             Poly::one(),
-            "incorrect inverse() impl: the inverse of f was y, because f * y == 1"
+            "{}: incorrect inverse() impl: the inverse of f was y, because f * y == 1",
+            type_name::<C>()
         );
         // Since all non-zero `C::Coeff` values *are* invertible in the integer field, `f * y` can't be a constant, either.
         if fy != Poly::zero() {
-            assert_ne!(fy.degree(), 0, "incorrect inverse() impl: the inverse of f was y*(c^1), because f * y is a non-zero constant c");
+            assert_ne!(
+                fy.degree(),
+                0,
+                "{}: incorrect inverse() impl: the inverse of f was y*(c^1), because f * y is a non-zero constant c",
+                type_name::<C>()
+            );
         }
     }
 }

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -8,7 +8,7 @@ use crate::{
         flat_karatsuba_mul, naive_cyclotomic_mul, new_unreduced_poly_modulus_slow,
         rec_karatsuba_mul, test::gen::rand_poly, Poly, PolyConf,
     },
-    TestRes,
+    MiddleRes, TestRes,
 };
 
 /// Test cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
@@ -17,6 +17,10 @@ fn test_cyclotomic_mul_rand_xnm1() {
     check_cyclotomic_mul_rand_xnm1::<TestRes, _>(naive_cyclotomic_mul);
     check_cyclotomic_mul_rand_xnm1::<TestRes, _>(rec_karatsuba_mul);
     check_cyclotomic_mul_rand_xnm1::<TestRes, _>(flat_karatsuba_mul);
+
+    check_cyclotomic_mul_rand_xnm1::<MiddleRes, _>(naive_cyclotomic_mul);
+    check_cyclotomic_mul_rand_xnm1::<MiddleRes, _>(rec_karatsuba_mul);
+    check_cyclotomic_mul_rand_xnm1::<MiddleRes, _>(flat_karatsuba_mul);
 }
 
 /// Check `mul_fn` correctly implements cyclotomic multiplication of a random polynomial by `X^{[C::MAX_POLY_DEGREE] - 1}`.
@@ -57,6 +61,10 @@ fn test_cyclotomic_mul_max_degree() {
     check_cyclotomic_mul_max_degree::<TestRes, _>(naive_cyclotomic_mul);
     check_cyclotomic_mul_max_degree::<TestRes, _>(rec_karatsuba_mul);
     check_cyclotomic_mul_max_degree::<TestRes, _>(flat_karatsuba_mul);
+
+    check_cyclotomic_mul_max_degree::<MiddleRes, _>(naive_cyclotomic_mul);
+    check_cyclotomic_mul_max_degree::<MiddleRes, _>(rec_karatsuba_mul);
+    check_cyclotomic_mul_max_degree::<MiddleRes, _>(flat_karatsuba_mul);
 }
 
 /// Check `mul_fn` correctly implements cyclotomic multiplication that results in `X^[C::MAX_POLY_DEGREE]`.
@@ -124,6 +132,7 @@ where
 /// Test recursive karatsuba, flat karatsuba, and naive cyclotomic multiplication of two random polynomials all produce the same result.
 #[test]
 fn test_karatsuba_mul_rand_consistent() {
+    // TestRes
     let p1: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE - 1);
     let p2: Poly<TestRes> = rand_poly(TestRes::MAX_POLY_DEGREE - 1);
 
@@ -141,6 +150,28 @@ fn test_karatsuba_mul_rand_consistent() {
 
     let flat_res = flat_karatsuba_mul(&p1, &p2);
     assert!(flat_res.degree() <= TestRes::MAX_POLY_DEGREE);
+
+    assert_eq!(expected, rec_res);
+    assert_eq!(expected, flat_res);
+
+    // MiddleRes
+    let p1: Poly<MiddleRes> = rand_poly(TestRes::MAX_POLY_DEGREE - 1);
+    let p2: Poly<MiddleRes> = rand_poly(TestRes::MAX_POLY_DEGREE - 1);
+
+    #[allow(clippy::int_plus_one)]
+    {
+        assert!(p1.degree() <= MiddleRes::MAX_POLY_DEGREE - 1);
+        assert!(p2.degree() <= MiddleRes::MAX_POLY_DEGREE - 1);
+    }
+
+    let expected = naive_cyclotomic_mul(&p1, &p2);
+    assert!(expected.degree() <= MiddleRes::MAX_POLY_DEGREE);
+
+    let rec_res = rec_karatsuba_mul(&p1, &p2);
+    assert!(rec_res.degree() <= MiddleRes::MAX_POLY_DEGREE);
+
+    let flat_res = flat_karatsuba_mul(&p1, &p2);
+    assert!(flat_res.degree() <= MiddleRes::MAX_POLY_DEGREE);
 
     assert_eq!(expected, rec_res);
     assert_eq!(expected, flat_res);

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -94,7 +94,7 @@ where
     // Manually calculate the reduced representation of X^N as the constant `MODULUS - 1`.
     let (q, x_max) = x_max
         .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<C>())
-        .expect("is divisible by X^C::MAX_POLY_DEGREE");
+        .unwrap_or_else(|| panic!("is divisible by X^{}::MAX_POLY_DEGREE", type_name::<C>()));
 
     assert_eq!(
         q,
@@ -133,15 +133,31 @@ where
         let p1 = Poly::xn(i);
         let p2 = Poly::xn(C::MAX_POLY_DEGREE - i);
 
-        if i == 0 || i == TestRes::MAX_POLY_DEGREE {
-            assert_eq!(p1.degree(), 0);
-            assert_eq!(p2.degree(), 0);
+        if i == 0 || i == C::MAX_POLY_DEGREE {
+            assert_eq!(
+                p1.degree(),
+                0,
+                "{}: p1: X^{i} degree {}: degree is inconsistent",
+                type_name::<C>(),
+                p1.degree(),
+            );
+            assert_eq!(
+                p2.degree(),
+                0,
+                "{}: p2: x^{} degree {}: degree is inconsistent",
+                type_name::<C>(),
+                C::MAX_POLY_DEGREE - i,
+                p2.degree(),
+            );
         } else {
             assert_eq!(
                 p1.degree() + p2.degree(),
                 C::MAX_POLY_DEGREE,
-                "{}",
-                type_name::<C>()
+                "{}: p1: X^{i} degree {} * p2: x^{} degree {}: degrees are inconsistent",
+                type_name::<C>(),
+                p1.degree(),
+                C::MAX_POLY_DEGREE - i,
+                p2.degree(),
             );
         }
 

--- a/eyelid-match-ops/src/primitives/poly/test/mul.rs
+++ b/eyelid-match-ops/src/primitives/poly/test/mul.rs
@@ -1,5 +1,7 @@
 //! Tests for polynomial multiplication.
 
+use std::any::type_name;
+
 use ark_ff::{One, Zero};
 use ark_poly::Polynomial;
 
@@ -32,27 +34,36 @@ where
 
     #[allow(clippy::int_plus_one)]
     {
-        assert!(p1.degree() <= C::MAX_POLY_DEGREE - 1);
+        assert!(
+            p1.degree() <= C::MAX_POLY_DEGREE - 1,
+            "{}",
+            type_name::<C>()
+        );
     }
 
     // Xˆ{N-1}, multiplying by it will rotate by N-1 and negate (except the first).
     let xnm1 = Poly::xn(C::MAX_POLY_DEGREE - 1);
 
-    assert_eq!(xnm1.degree(), C::MAX_POLY_DEGREE - 1);
+    assert_eq!(
+        xnm1.degree(),
+        C::MAX_POLY_DEGREE - 1,
+        "{}",
+        type_name::<C>()
+    );
 
     let res = mul_fn(&p1, &xnm1);
-    assert!(res.degree() <= C::MAX_POLY_DEGREE);
+    assert!(res.degree() <= C::MAX_POLY_DEGREE, "{}", type_name::<C>());
 
     for i in 0..C::MAX_POLY_DEGREE - 1 {
         // Negative numbers are automatically converted to canonical
         // representation in the interval [0, MODULUS)
-        assert_eq!(res[i], -p1[i + 1]);
+        assert_eq!(res[i], -p1[i + 1], "{}", type_name::<C>());
     }
-    assert_eq!(res[C::MAX_POLY_DEGREE - 1], p1[0]);
+    assert_eq!(res[C::MAX_POLY_DEGREE - 1], p1[0], "{}", type_name::<C>());
 
     // Zero leading coefficients aren't stored.
     // `degree()` panics if the leading coefficient is zero anyway.
-    assert!(res.degree() < C::MAX_POLY_DEGREE);
+    assert!(res.degree() < C::MAX_POLY_DEGREE, "{}", type_name::<C>());
 }
 
 /// Test cyclotomic multiplication that results in `X^[C::MAX_POLY_DEGREE]`.
@@ -85,11 +96,18 @@ where
         .divide_with_q_and_r(&new_unreduced_poly_modulus_slow::<C>())
         .expect("is divisible by X^C::MAX_POLY_DEGREE");
 
-    assert_eq!(q, Poly::from_coefficients_vec(vec![C::Coeff::one()]));
+    assert_eq!(
+        q,
+        Poly::from_coefficients_vec(vec![C::Coeff::one()]),
+        "{}",
+        type_name::<C>()
+    );
     assert_eq!(
         x_max,
         // TODO: should `MODULUS - 1` be a constant?
         Poly::from_coefficients_vec(vec![C::Coeff::zero() - C::Coeff::one()]),
+        "{}",
+        type_name::<C>()
     );
 
     for i in 0..=C::MAX_POLY_DEGREE {
@@ -119,13 +137,24 @@ where
             assert_eq!(p1.degree(), 0);
             assert_eq!(p2.degree(), 0);
         } else {
-            assert_eq!(p1.degree() + p2.degree(), C::MAX_POLY_DEGREE);
+            assert_eq!(
+                p1.degree() + p2.degree(),
+                C::MAX_POLY_DEGREE,
+                "{}",
+                type_name::<C>()
+            );
         }
 
         let res = mul_fn(&p1, &p2);
 
         // Make sure it's X^N
-        assert_eq!(res, x_max, "x^{i} * x^{}", C::MAX_POLY_DEGREE - i);
+        assert_eq!(
+            res,
+            x_max,
+            "{}: x^{i} * x^{}",
+            type_name::<C>(),
+            C::MAX_POLY_DEGREE - i
+        );
     }
 }
 

--- a/eyelid-match-ops/src/primitives/yashe/conf.rs
+++ b/eyelid-match-ops/src/primitives/yashe/conf.rs
@@ -11,11 +11,11 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive;
 
 use crate::{
+    encoded::conf::{FullRes, MiddleRes},
     primitives::poly::{
-        modular_poly::conf::{FullResBN, IrisBitsBN, MiddleResBN},
+        modular_poly::conf::{FullResBN, MiddleResBN},
         Poly, PolyConf,
     },
-    FullRes, IrisBits, MiddleRes,
 };
 
 #[cfg(tiny_poly)]
@@ -296,15 +296,6 @@ where
     };
 }
 
-/// Iris bit length polynomial parameters.
-///
-/// This uses the full number of iris bits, which gives an upper bound on benchmarks.
-impl YasheConf for IrisBits {
-    type PolyBN = IrisBitsBN;
-
-    const T: u64 = 2048;
-}
-
 /// Full resolution polynomial parameters.
 ///
 /// These are the parameters for full resolution, according to the Inversed Tech report.
@@ -328,10 +319,10 @@ impl YasheConf for MiddleRes {
 /// Tiny test polynomials, used for finding edge cases in tests.
 ///
 /// The test parameters are specifically chosen to make failing tests easy to read and diagnose.
+///
 /// TODO: these parameters don't work for encryption and decryption, find some that do.
 #[cfg(tiny_poly)]
 impl YasheConf for TinyTest {
-    // TODO: find a coefficient that works here
     type PolyBN = TinyTestBN;
 
     /// Limited to the modulus of the underlying `Coeff` type.

--- a/eyelid-match-ops/src/primitives/yashe/conf.rs
+++ b/eyelid-match-ops/src/primitives/yashe/conf.rs
@@ -302,8 +302,9 @@ where
 impl YasheConf for FullRes {
     type PolyBN = FullResBN;
 
-    // VERIFY: max T should be 2^15, not 2^11
-    const T: u64 = 2048;
+    // VERIFY: max T should be 2^15, not 2^12
+    // Larger values cause failures in the positive_multiplication_test().
+    const T: u64 = 4096;
 }
 
 /// Middle resolution polynomial parameters.
@@ -313,6 +314,7 @@ impl YasheConf for MiddleRes {
     type PolyBN = MiddleResBN;
 
     // VERIFY: max T should be 2^12, not 2^8
+    // Larger values cause failures in the positive_multiplication_test().
     const T: u64 = 256;
 }
 

--- a/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
@@ -1,5 +1,7 @@
 //! Unit tests for Encryption and Decryption
 
+use std::any::type_name;
+
 use crate::{
     primitives::yashe::{Yashe, YasheConf},
     MiddleRes, TestRes,
@@ -17,7 +19,7 @@ where
     let c = ctx.encrypt(m.clone(), &public_key, &mut rng);
     let m_dec = ctx.decrypt(c.clone(), &private_key);
 
-    assert_eq!(m, m_dec);
+    assert_eq!(m, m_dec, "{}", type_name::<C>());
 }
 
 #[test]

--- a/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
@@ -4,7 +4,7 @@ use std::any::type_name;
 
 use crate::{
     primitives::yashe::{Yashe, YasheConf},
-    MiddleRes, TestRes,
+    FullRes, MiddleRes,
 };
 
 fn encrypt_decrypt_helper<C: YasheConf>()
@@ -25,6 +25,7 @@ where
 #[test]
 fn encrypt_decrypt_test() {
     // Testing multiple configs is important for code coverage, and to check for hard-coded assumptions.
-    encrypt_decrypt_helper::<TestRes>();
+    // TODO: get TinyTest working here
     encrypt_decrypt_helper::<MiddleRes>();
+    encrypt_decrypt_helper::<FullRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/encdec.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     primitives::yashe::{Yashe, YasheConf},
-    FullRes, IrisBits,
+    MiddleRes, TestRes,
 };
 
 fn encrypt_decrypt_helper<C: YasheConf>()
@@ -22,11 +22,7 @@ where
 
 #[test]
 fn encrypt_decrypt_test() {
-    // The TinyTest config doesn't work for encryption, so we test full resolution,
-    // and a large polynomial with the same number of terms as the number of iris bits.
     // Testing multiple configs is important for code coverage, and to check for hard-coded assumptions.
-    //
-    // TODO: find a config that does work and use it for TestRes/TinyPoly.
-    encrypt_decrypt_helper::<FullRes>();
-    encrypt_decrypt_helper::<IrisBits>();
+    encrypt_decrypt_helper::<TestRes>();
+    encrypt_decrypt_helper::<MiddleRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/hom.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/hom.rs
@@ -4,7 +4,7 @@ use std::any::type_name;
 
 use crate::{
     primitives::yashe::{Yashe, YasheConf},
-    MiddleRes, TestRes,
+    FullRes, MiddleRes,
 };
 
 fn homomorphic_addition_helper<C: YasheConf>()
@@ -80,14 +80,16 @@ where
 
 #[test]
 fn homomorphic_addition_test() {
-    homomorphic_addition_helper::<TestRes>();
+    // Testing multiple configs is important for code coverage, and to check for hard-coded assumptions.
+    // TODO: get TinyTest working in this module
     homomorphic_addition_helper::<MiddleRes>();
+    homomorphic_addition_helper::<FullRes>();
 }
 
 #[test]
 fn homomorphic_multiplication_test() {
-    homomorphic_multiplication_helper_positive::<TestRes>();
-    homomorphic_multiplication_helper_negative::<TestRes>();
     homomorphic_multiplication_helper_positive::<MiddleRes>();
     homomorphic_multiplication_helper_negative::<MiddleRes>();
+    homomorphic_multiplication_helper_positive::<FullRes>();
+    homomorphic_multiplication_helper_negative::<FullRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/hom.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/hom.rs
@@ -87,9 +87,13 @@ fn homomorphic_addition_test() {
 }
 
 #[test]
-fn homomorphic_multiplication_test() {
-    homomorphic_multiplication_helper_positive::<MiddleRes>();
+fn homomorphic_negative_multiplication_test() {
     homomorphic_multiplication_helper_negative::<MiddleRes>();
-    homomorphic_multiplication_helper_positive::<FullRes>();
     homomorphic_multiplication_helper_negative::<FullRes>();
+}
+
+#[test]
+fn homomorphic_positive_multiplication_test() {
+    homomorphic_multiplication_helper_positive::<MiddleRes>();
+    homomorphic_multiplication_helper_positive::<FullRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/hom.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/hom.rs
@@ -1,8 +1,10 @@
 //! Unit tests for homomorphic operations
 
+use std::any::type_name;
+
 use crate::{
     primitives::yashe::{Yashe, YasheConf},
-    FullRes, MiddleRes,
+    MiddleRes, TestRes,
 };
 
 fn homomorphic_addition_helper<C: YasheConf>()
@@ -22,7 +24,7 @@ where
     // Additions can be regularly decrypted using the private key
     let m_dec = ctx.decrypt(c.clone(), &private_key);
 
-    assert_eq!(m, m_dec);
+    assert_eq!(m, m_dec, "addition test failed for {}", type_name::<C>());
 }
 
 fn homomorphic_multiplication_helper_negative<C: YasheConf>()
@@ -42,7 +44,12 @@ where
     // Multiplications can't be regularly decrypted using the private key
     let m_dec = ctx.decrypt(c.clone(), &private_key);
 
-    assert_ne!(m, m_dec);
+    assert_ne!(
+        m,
+        m_dec,
+        "negative multiplication test failed for {}",
+        type_name::<C>()
+    );
 }
 
 fn homomorphic_multiplication_helper_positive<C: YasheConf>()
@@ -61,19 +68,26 @@ where
     let c = ctx.ciphertext_mul(c1, c2);
     let m_dec = ctx.decrypt_mul(c.clone(), &private_key);
 
-    assert_eq!(m, m_dec);
+    assert_eq!(
+        m,
+        m_dec,
+        "positive multiplication test failed for {}",
+        type_name::<C>()
+    );
 }
+
+// TODO: get these tests working with TestRes
 
 #[test]
 fn homomorphic_addition_test() {
-    homomorphic_addition_helper::<FullRes>();
+    homomorphic_addition_helper::<TestRes>();
     homomorphic_addition_helper::<MiddleRes>();
 }
 
 #[test]
 fn homomorphic_multiplication_test() {
-    homomorphic_multiplication_helper_negative::<FullRes>();
-    homomorphic_multiplication_helper_positive::<FullRes>();
-    homomorphic_multiplication_helper_negative::<MiddleRes>();
+    homomorphic_multiplication_helper_positive::<TestRes>();
+    homomorphic_multiplication_helper_negative::<TestRes>();
     homomorphic_multiplication_helper_positive::<MiddleRes>();
+    homomorphic_multiplication_helper_negative::<MiddleRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -8,7 +8,7 @@ use crate::{
         poly::Poly,
         yashe::{Yashe, YasheConf},
     },
-    TestRes,
+    MiddleRes, TestRes,
 };
 
 /// Auxiliary function for testing key generation
@@ -38,4 +38,5 @@ where
 #[test]
 fn test_keygen() {
     keygen_helper::<TestRes>();
+    keygen_helper::<MiddleRes>();
 }

--- a/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
+++ b/eyelid-match-ops/src/primitives/yashe/test/keygen.rs
@@ -1,5 +1,7 @@
 //! Unit tests for Key Generation
 
+use std::any::type_name;
+
 use ark_ff::One;
 use ark_poly::Polynomial;
 
@@ -24,15 +26,23 @@ where
 
     assert_eq!(
         private_key.f[0] * C::t_as_coeff() + C::Coeff::one(),
-        private_key.priv_key[0]
+        private_key.priv_key[0],
+        "{}",
+        type_name::<C>()
     );
 
     assert_eq!(
         private_key.priv_key * priv_key_inv.expect("Private key must be invertible"),
-        Poly::one()
+        Poly::one(),
+        "{}",
+        type_name::<C>()
     );
 
-    assert!(public_key.h.degree() < C::MAX_POLY_DEGREE);
+    assert!(
+        public_key.h.degree() < C::MAX_POLY_DEGREE,
+        "{}",
+        type_name::<C>()
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Dimension Changes

Currently we're using iris dimensions of 160x80, but the production dimensions are slightly different. So this PR changes those sizes to match the production system.

### Design Changes

As part of this change, we need to fix some design issues:
- [x] Split iris bit configurations and encoding configurations
- [x] Avoid confusion between the number of rows in a full iris code, and the number of rows per encoded block

So this PR creates two different kinds of configs:
- `FullBits`, `MediumBits`, `TinyTest` - the bit sizes and dimensions of the full iris codes and plaintexts
- `FullRes`, `MediumRes`, `TinyTest` - the block sizes and polynomial sizes for encoding (and encryption)

These design changes are needed for ticket #89.

### Cleanups

It also improves performance and ease of use:
- [x] Make polynomial sizes tight, and automatic, by calculating them from the iris size
- [x] Rename config types to be consistent with each other

And fixes some bugs:
- [x] Calculate polynomial sizes from the encoded size plus padding
- [x] Add missing `impl EncodedConf for MiddleRes`
- [x] Add missing tests and benchmarks for `Test*`/`Middle*` (or `Middle*`/`Full*` if `TinyTest` doesn't work)
    - [x] Remove a hard coded `TestRes` in some tests
- [x] Add missing types and inputs/outputs to test failure logs
- [x] Cleanup redundant tests and benchmarks
- [x] Skip a test case that can fail at random with tiny test iris codes

Close #102 
Part of #89, #100
